### PR TITLE
Hotfix switching to static python and bokeh package

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.11.0-bullseye
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/cs-http.Dockerfile
+++ b/cs-http.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.11.0-bullseye
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/http-api.Dockerfile
+++ b/http-api.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:latest
+FROM python:3.11.0-bullseye
 WORKDIR /app
 COPY requirements.txt .
 RUN pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-bokeh
+bokeh==2.4.3
 sqlalchemy
 alembic
 psycopg2-binary


### PR DESCRIPTION
Uses `3.11.0-bullseye` and `bokeh==2.4.3`