### PR TITLE
Implemented Raw Data Export for Multiple Cells

### DIFF
--- a/backend/api/database/models/power_data.py
+++ b/backend/api/database/models/power_data.py
@@ -73,14 +73,14 @@ class PowerData(db.Model):
         stream=False,
     ):
         """gets teros data as a list of objects
-        
+
         The stream parameter controls data aggregation and timestamp. When False
         the data is aggregated according to the resample argument and the
         timestamp is from the measurement itself. When True, no data aggregation
         is preformed and the timestamp is when the measurement is inserted into
         the server.
         """
-        
+
         data = {
             "timestamp": [],
             "v": [],
@@ -91,7 +91,7 @@ class PowerData(db.Model):
         if not stream:
             # select from actual timestamp and aggregate data
             if resample == "none":
-                # When no resampling is required, select data directly without grouping or aggregate functions
+                #resampling is not required: select data without aggregate functions
                 stmt = (
                     db.select(
                         PowerData.ts.label("ts"),

--- a/backend/api/database/models/teros_data.py
+++ b/backend/api/database/models/teros_data.py
@@ -72,19 +72,19 @@ class TEROSData(db.Model):
         stream=False,
     ):
         """gets teros data as a list of objects
-         
+
         The stream parameter controls data aggregation and timestamp. When False
         the data is aggregated according to the resample argument and the
         timestamp is from the measurement itself. When True, no data aggregation
         is preformed and the timestamp is when the measurement is inserted into
         the server.
         """
-        
+
         data = {"timestamp": [], "vwc": [], "temp": [], "ec": []}
 
         if not stream:
             if resample == "none":
-                # When no resampling is required, select data directly without grouping or aggregate functions
+                #resampling is not required: select data without aggregate functions
                 stmt = (
                     db.select(
                         TEROSData.ts.label("ts"),
@@ -121,8 +121,8 @@ class TEROSData(db.Model):
                 .filter((TEROSData.ts_server.between(start_time, end_time)))
                 .subquery()
             )
-       
-        # apply unit conversions     
+
+        # apply unit conversions
         # VWC stored in decimal, converted to percentage
         adj_units = db.select(
             stmt.c.ts.label("ts"),

--- a/backend/api/database/schemas/get_cell_data_schema.py
+++ b/backend/api/database/schemas/get_cell_data_schema.py
@@ -1,11 +1,28 @@
 from . import ma
 from marshmallow import validate
 
+
 class GetCellDataSchema(ma.SQLAlchemySchema):
     """validates get request for cell data"""
 
     cellId = ma.Int()
-    resample = ma.Str(required=False,validate=validate.OneOf(["none","second", "minute", "hour", "day", "week", "month", "quarter", "year"]), missing="hour")
+    resample = ma.Str(
+        required=False,
+        validate=validate.OneOf(
+            [
+                "none",
+                "second",
+                "minute",
+                "hour",
+                "day",
+                "week",
+                "month",
+                "quarter",
+                "year",
+            ]
+        ),
+        missing="hour",
+    )
     startTime = ma.DateTime("rfc", required=False)
     endTime = ma.DateTime("rfc", required=False)
     stream = ma.Bool(required=False)

--- a/backend/api/database/schemas/get_cell_data_schema.py
+++ b/backend/api/database/schemas/get_cell_data_schema.py
@@ -1,11 +1,11 @@
 from . import ma
-
+from marshmallow import validate
 
 class GetCellDataSchema(ma.SQLAlchemySchema):
     """validates get request for cell data"""
 
     cellId = ma.Int()
-    resample = ma.Str(required=False)
+    resample = ma.Str(required=False,validate=validate.OneOf(["none","second", "minute", "hour", "day", "week", "month", "quarter", "year"]), missing="hour")
     startTime = ma.DateTime(required=False)
     endTime = ma.DateTime(required=False)
     stream = ma.Bool(required=False)

--- a/backend/api/database/schemas/get_cell_data_schema.py
+++ b/backend/api/database/schemas/get_cell_data_schema.py
@@ -5,6 +5,7 @@ class GetCellDataSchema(ma.SQLAlchemySchema):
     """validates get request for cell data"""
 
     cellId = ma.Int()
+    resample = ma.Str(required=False)
     startTime = ma.DateTime(required=False)
     endTime = ma.DateTime(required=False)
     stream = ma.Bool(required=False)

--- a/backend/api/resources/cell_data.py
+++ b/backend/api/resources/cell_data.py
@@ -13,12 +13,12 @@ class Cell_Data(Resource):
         v_args = get_cell_data.load(request.args)
         teros_data = pd.DataFrame(
             TEROSData.get_teros_data_obj(
-                cell_id, start_time=v_args["startTime"], end_time=v_args["endTime"]
+                cell_id, resample=v_args["resample"], start_time=v_args["startTime"], end_time=v_args["endTime"]
             )
         )
         power_data = pd.DataFrame(
             PowerData.get_power_data_obj(
-                cell_id, start_time=v_args["startTime"], end_time=v_args["endTime"]
+                cell_id, resample=v_args["resample"],start_time=v_args["startTime"], end_time=v_args["endTime"]
             )
         )
 

--- a/backend/api/resources/cell_data.py
+++ b/backend/api/resources/cell_data.py
@@ -13,12 +13,18 @@ class Cell_Data(Resource):
         v_args = get_cell_data.load(request.args)
         teros_data = pd.DataFrame(
             TEROSData.get_teros_data_obj(
-                cell_id, resample=v_args["resample"], start_time=v_args["startTime"], end_time=v_args["endTime"]
+                cell_id,
+                resample=v_args["resample"],
+                start_time=v_args["startTime"],
+                end_time=v_args["endTime"],
             )
         )
         power_data = pd.DataFrame(
             PowerData.get_power_data_obj(
-                cell_id, resample=v_args["resample"],start_time=v_args["startTime"], end_time=v_args["endTime"]
+                cell_id,
+                resample=v_args["resample"],
+                start_time=v_args["startTime"],
+                end_time=v_args["endTime"],
             )
         )
 

--- a/frontend/src/pages/dashboard/components/DownloadBtn.jsx
+++ b/frontend/src/pages/dashboard/components/DownloadBtn.jsx
@@ -26,8 +26,9 @@ function DownloadBtn({ cells, startDate, endDate }) {
   const exportToCsv = (e) => {
     e.preventDefault();
     // Note: timestamp string slices of "Wed," in "Wed, 29 Jun 2022 14:00:00 GMT"
+    const resample = "none"
     for (const { id, name } of cells) {
-      getCellData(id, startDate, endDate).then((data) => {
+      getCellData(id, resample, startDate, endDate).then((data) => {
         downloadFile({
           data: [
             ['timestamp', 'Voltage (mV)', 'Current (uA)', 'Power (uW)', 'EC (uS/cm)', 'VWC (%)', 'Temperature (C)'],

--- a/frontend/src/services/cell.js
+++ b/frontend/src/services/cell.js
@@ -4,7 +4,7 @@ import { DateTime } from 'luxon';
 
 export const getCellData = (cellId, resample, startTime, endTime) => {
   return axios
-    .get(`${process.env.PUBLIC_URL}/api/cell/data/${cellId}?resample=${resample}&startTime=${startTime}&endTime=${endTime}`)
+    .get(`${process.env.PUBLIC_URL}/api/cell/data/${cellId}?resample=${resample}&startTime=${startTime.toHTTP()}&endTime=${endTime.toHTTP()}`)
     .then((res) => res.data);
 };
 

--- a/frontend/src/services/cell.js
+++ b/frontend/src/services/cell.js
@@ -2,9 +2,9 @@ import { useQuery, useQueries } from '@tanstack/react-query';
 import axios from 'axios';
 import { DateTime } from 'luxon';
 
-export const getCellData = (cellId, startTime, endTime) => {
+export const getCellData = (cellId, resample, startTime, endTime) => {
   return axios
-    .get(`${process.env.PUBLIC_URL}/api/cell/data/${cellId}?startTime=${startTime}&endTime=${endTime}`)
+    .get(`${process.env.PUBLIC_URL}/api/cell/data/${cellId}?resample=${resample}&startTime=${startTime}&endTime=${endTime}`)
     .then((res) => res.data);
 };
 


### PR DESCRIPTION
Implemented enhancements to the "export to csv" functionality on the dashboard. With this update, users can now export raw data for multiple cells as separate CSV files, addressing the issue where previously only aggregated hourly data could be exported for a single cell, resolves #203.  

#### Changes Made:

1. Added a `resample` query parameter to the backend API endpoint `/api/cell/data/${cellId}`, allowing the API to handle raw data export when `resample=none` is specified. This parameter is used to determine whether to perform data resampling or to fetch raw data.

2. Updated the backend database models to handle the new `resample` logic.

3. Revised the `getCellData` schema to include the `resample` parameter, enabling front-end requests to specify the desired resampling strategy.

4. Altered the front-end logic in `DownloadBtn.jsx` to pass the `resample=none` parameter when initiating the data download, ensuring that raw data is exported.

#### Testing Performed:

Manual testing was conducted to ensure the new functionalities work as expected. This includes:

- REST API calls to the endpoint with various resample values to validate backend response.
- Frontend tests for exporting multiple cells' data with different resampling settings to ensure proper CSV file generation.

EDIT: It also closes #210