### PR TITLE
fixed datetime validation for positive offeset timezones

### DIFF
--- a/backend/api/database/schemas/get_cell_data_schema.py
+++ b/backend/api/database/schemas/get_cell_data_schema.py
@@ -5,8 +5,8 @@ class GetCellDataSchema(ma.SQLAlchemySchema):
     """validates get request for cell data"""
 
     cellId = ma.Int()
-    startTime = ma.DateTime(required=False)
-    endTime = ma.DateTime(required=False)
+    startTime = ma.DateTime("rfc", required=False)
+    endTime = ma.DateTime("rfc", required=False)
     stream = ma.Bool(required=False)
     # @validates('time_created')
     # def is_not_in_future(value):

--- a/frontend/src/pages/dashboard/components/PowerCharts.jsx
+++ b/frontend/src/pages/dashboard/components/PowerCharts.jsx
@@ -13,6 +13,9 @@ function PowerCharts({ cells, startDate, endDate, stream }) {
     labels: [],
     datasets: [],
   };
+  // let DateTime = dt.fromObject({
+  //   zone: "Asia/Mumbai"
+  // })
   const [vChartData, setVChartData] = useState(chartSettings);
   const [pwrChartData, setPwrChartData] = useState(chartSettings);
   const [loadedCells, setLoadedCells] = useState([]);
@@ -34,8 +37,8 @@ function PowerCharts({ cells, startDate, endDate, stream }) {
       data[id] = {
         name: name,
         powerData: await (stream
-          ? streamPowerData(id, DateTime.now().minus({ second: 20 }), DateTime.now(), true)
-          : getPowerData(id, startDate, endDate)),
+          ? streamPowerData(id, DateTime.now().minus({ second: 20 }).toHTTP(), DateTime.now().toHTTP(), true)
+          : getPowerData(id, startDate.toHTTP(), endDate.toHTTP())),
       };
     }
     return data;
@@ -50,8 +53,8 @@ function PowerCharts({ cells, startDate, endDate, stream }) {
         name: name,
         powerData: await streamPowerData(
           id,
-          DateTime.now().minus({ millisecond: interval + 29000 }),
-          DateTime.now(),
+          DateTime.now().minus({ millisecond: interval + 29000 }).toHTTP(),
+          DateTime.now().toHTTP(),
           true,
         ),
       };

--- a/frontend/src/pages/dashboard/components/TerosCharts.jsx
+++ b/frontend/src/pages/dashboard/components/TerosCharts.jsx
@@ -34,8 +34,8 @@ function TerosCharts({ cells, startDate, endDate, stream }) {
       data[id] = {
         name: name,
         terosData: await (stream
-          ? streamTerosData(id, DateTime.now().minus({ second: 20 }), DateTime.now(), true)
-          : getTerosData(id, startDate, endDate)),
+          ? streamTerosData(id, DateTime.now().minus({ second: 20 }).toHTTP(), DateTime.now().toHTTP(), true)
+          : getTerosData(id, startDate.toHTTP(), endDate.toHTTP())),
       };
     }
     return data;
@@ -50,8 +50,8 @@ function TerosCharts({ cells, startDate, endDate, stream }) {
         name: name,
         terosData: await streamTerosData(
           id,
-          DateTime.now().minus({ millisecond: interval + 29000 }),
-          DateTime.now(),
+          DateTime.now().minus({ millisecond: interval + 29000 }).toHTTP(),
+          DateTime.now().toHTTP(),
           true,
         ),
       };


### PR DESCRIPTION
'+' symbol was not decoding correctly in datetimes formated with a positive offset. Needed to encode the datetime before sending it over an HTTP request