### PR TITLE
Updated soil-power-sensor-protobuf to ents

### DIFF
--- a/backend/api/resources/util.py
+++ b/backend/api/resources/util.py
@@ -6,7 +6,7 @@ author: John Madden <jmadden173@pm.me>
 from datetime import datetime
 
 from flask import Response
-from soil_power_sensor_protobuf.proto import encode_response, decode_measurement
+from ents.proto import encode_response, decode_measurement
 
 from ..models.power_data import PowerData
 from ..models.teros_data import TEROSData

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -20,6 +20,6 @@ redis
 PyJWT
 Requests
 google-auth
-soil-power-sensor-protobuf @ https://ents-python-package.s3.us-west-2.amazonaws.com/soil_power_sensor_protobuf-2.2.2.tar.gz
+ents
 gevent
 celery[redis,gevent,sqlalchemy,sqs]


### PR DESCRIPTION
This updates the `soil-power-sensor-protobuf` package to the newly named `ents`.

After the firmware branch is tagged and published check that the environment can be setup locally before we merge this branch.