### PR TITLE
set ents python package to 2.3.7

### DIFF
--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -21,7 +21,7 @@ redis
 PyJWT
 Requests
 google-auth
-ents==2.3.5
+ents==2.3.7
 gevent
 eventlet
 celery[redis,gevent,sqlalchemy,sqs]


### PR DESCRIPTION
@jlin143 Only merge this PR when the Firmware side PR has gone through that updates the Python package to 2.3.7