### PR TITLE
Fix raw Teros12 readings

### DIFF
--- a/frontend/src/pages/dashboard/components/UnifiedChart.jsx
+++ b/frontend/src/pages/dashboard/components/UnifiedChart.jsx
@@ -22,8 +22,8 @@ const CHART_CONFIGS = {
   },
   teros12_vwc: {
     sensor_name: 'TEROS12_VWC',
-    measurements: ['Volumetric Water Content'],
-    units: ['%'],
+    measurements: ['Volumetric Water Content (Raw)'],
+    units: ['N/A'],
     axisIds: ['y'],
     chartId: 'teros12VWC',
   },


### PR DESCRIPTION
Updated measurement name and units for raw Teros12 plot.

Api gets updated from:

https://dirtviz.jlab.ucsc.edu/api/sensor/?name=TEROS12_VWC&cellId=2108&measurement=Volumetric%20Water%20Content&startTime=Tue,%2027%20Jan%202026%2022:31:27%20GMT&endTime=Sun,%2015%20Feb%202026%2022:31:27%20GMT&resample=hour

to 

https://dirtviz.jlab.ucsc.edu/api/sensor/?name=TEROS12_VWC&cellId=2108&measurement=Volumetric%20Water%20Content%20(Raw)&startTime=Tue,%2027%20Jan%202026%2022:31:27%20GMT&endTime=Sun,%2015%20Feb%202026%2022:31:27%20GMT&resample=hour