### PR TITLE
pcap02

### DIFF
--- a/frontend/src/pages/dashboard/components/UnifiedChart.jsx
+++ b/frontend/src/pages/dashboard/components/UnifiedChart.jsx
@@ -104,6 +104,13 @@ const CHART_CONFIGS = {
     axisIds: ['y'],
     chartId: 'waterFlow',
   },
+  pcap02: {
+    sensor_name: 'PCAP02_CAPACITANCE',
+    measurements: ['Capacitance'],
+    units: ['pF'],
+    axisIds: ['y'],
+    chartId: 'pcap02',
+  },
 };
 
 function UnifiedChart({ type, cells, startDate, endDate, stream, liveData, processedData, onDataStatusChange }) {


### PR DESCRIPTION
This should address the issue of the server receiving PCAP02 capacitance data, but not displaying it on a chart.

Related files:
- https://github.com/jlab-sensing/ENTS-node-firmware/blob/main/proto/sensor.proto#L48
- https://github.com/jlab-sensing/ENTS-node-firmware/blob/main/python/src/ents/proto/sensor.py#L152
    - Pending name and unit change in https://github.com/jlab-sensing/ENTS-node-firmware/pull/303
- https://github.com/jlab-sensing/ENTS-node-firmware/blob/main/proto/soil_power_sensor.proto#L168
