### PR TITLE
Fix chart timesync: use one non-stream x-axis date range across all charts

### DIFF
--- a/frontend/src/charts/ChartWrapper.jsx
+++ b/frontend/src/charts/ChartWrapper.jsx
@@ -111,8 +111,12 @@ function ChartWrapper({ id, data, options, stream, onResampleChange }) {
     if (chartRef.current) {
       for (const { axis, axisMin, axisMax } of axesWithScaleKeys) {
         if (chartRef.current.scales[axis]) {
-          chartRef.current.scales[axis].options.min = scaleRef[axisMin];
-          chartRef.current.scales[axis].options.max = scaleRef[axisMax];
+          if (scaleRef[axisMin] !== undefined) {
+            chartRef.current.scales[axis].options.min = scaleRef[axisMin];
+          }
+          if (scaleRef[axisMax] !== undefined) {
+            chartRef.current.scales[axis].options.max = scaleRef[axisMax];
+          }
         }
       }
       chartRef.current.update();
@@ -132,6 +136,7 @@ function ChartWrapper({ id, data, options, stream, onResampleChange }) {
     if (chartRef.current) {
       chartRef.current.resetZoom();
       chartRef.current.update();
+      setScaleRef({});
     }
   };
   const handleToggleZoom = () => {
@@ -191,18 +196,16 @@ function ChartWrapper({ id, data, options, stream, onResampleChange }) {
   /** Maintain zoom and pan ref from previous render */
   useEffect(() => {
     if (chartRef.current) {
-      if (prevScaleRef != undefined) {
-        setScales(prevScaleRef);
-        chartRef.current.update();
-      } else if (scaleRef != undefined) {
+      if (scaleRef != undefined) {
         setScales(scaleRef);
+        chartRef.current.update();
       }
       return;
     }
 
     // TODO: refactor for better state management, useCallback for setting scaleRef
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [zoomSelected, panSelected, prevScaleRef, scaleRef, data]);
+  }, [zoomSelected, panSelected, scaleRef, data]);
 
   //** Maintain zoom and pan when streaming new data */
   useEffect(() => {
@@ -305,7 +308,7 @@ function ChartWrapper({ id, data, options, stream, onResampleChange }) {
             <Box component='img' src={reset} sx={{ width: '16px', height: '16px' }}></Box>
           </ToggleButton>
         </Tooltip>
-        
+
         {/* Show additional controls only when not streaming */}
         {!stream && (
           <>

--- a/frontend/src/charts/PwrChart/PwrChart.jsx
+++ b/frontend/src/charts/PwrChart/PwrChart.jsx
@@ -3,10 +3,12 @@ import { DateTime } from 'luxon';
 import PropTypes from 'prop-types';
 import { React } from 'react';
 import { getAxisBoundsAndStepValues } from '../alignAxis';
+import { getNonStreamTimeDomain } from '../timeDomain';
 import ChartWrapper from '../ChartWrapper';
 
-export default function PwrChart({ data, stream, onResampleChange }) {
+export default function PwrChart({ data, stream, startDate, endDate, onResampleChange }) {
   const { leftYMin, leftYMax, leftYStep } = getAxisBoundsAndStepValues(data.datasets, [], 10, 5);
+  const nonStreamXDomain = getNonStreamTimeDomain(stream, startDate, endDate);
 
   const chartOptions = {
     maintainAspectRatio: false,
@@ -34,6 +36,7 @@ export default function PwrChart({ data, stream, onResampleChange }) {
             day: 'MM/dd',
           },
         },
+        ...nonStreamXDomain,
       },
       y: {
         type: 'linear',

--- a/frontend/src/charts/TempChart/TempChart.jsx
+++ b/frontend/src/charts/TempChart/TempChart.jsx
@@ -3,10 +3,12 @@ import { DateTime } from 'luxon';
 import PropTypes from 'prop-types';
 import { React } from 'react';
 import { getAxisBoundsAndStepValues } from '../alignAxis';
+import { getNonStreamTimeDomain } from '../timeDomain';
 import ChartWrapper from '../ChartWrapper';
 
-export default function TempChart({ data, stream, onResampleChange }) {
+export default function TempChart({ data, stream, startDate, endDate, onResampleChange }) {
   const { leftYMin, leftYMax, leftYStep } = getAxisBoundsAndStepValues(data.datasets, [], 10, 5);
+  const nonStreamXDomain = getNonStreamTimeDomain(stream, startDate, endDate);
 
   const chartOptions = {
     maintainAspectRatio: false,
@@ -34,6 +36,7 @@ export default function TempChart({ data, stream, onResampleChange }) {
             day: 'MM/dd',
           },
         },
+        ...nonStreamXDomain,
       },
       y: {
         type: 'linear',

--- a/frontend/src/charts/UniversalChart.jsx
+++ b/frontend/src/charts/UniversalChart.jsx
@@ -3,12 +3,15 @@ import { DateTime } from 'luxon';
 import PropTypes from 'prop-types';
 import { React } from 'react';
 import { getAxisBoundsAndStepValues } from './alignAxis';
+import { getNonStreamTimeDomain } from './timeDomain';
 import ChartWrapper from './ChartWrapper';
 import { chartPlugins } from './plugins';
 
-export default function UniversalChart({ data, stream, chartId, measurements, units, axisIds, onResampleChange }) {
+export default function UniversalChart({ data, stream, chartId, measurements, units, axisIds, startDate, endDate, onResampleChange }) {
   // Build chart options dynamically based on measurements
   const buildChartOptions = () => {
+    const nonStreamXDomain = getNonStreamTimeDomain(stream, startDate, endDate);
+
     const scales = {
       x: {
         position: 'bottom',
@@ -48,6 +51,7 @@ export default function UniversalChart({ data, stream, chartId, measurements, un
           suggestedMin: DateTime.now().minus({ second: 10 }).toJSON(),
           suggestedMax: DateTime.now().toJSON(),
         }),
+        ...nonStreamXDomain,
       },
     };
 

--- a/frontend/src/charts/VChart/VChart.jsx
+++ b/frontend/src/charts/VChart/VChart.jsx
@@ -3,15 +3,17 @@ import { DateTime } from 'luxon';
 import PropTypes from 'prop-types';
 import { React } from 'react';
 import { getAxisBoundsAndStepValues } from '../alignAxis';
+import { getNonStreamTimeDomain } from '../timeDomain';
 import ChartWrapper from '../ChartWrapper';
 
-export default function VChart({ data, stream, onResampleChange }) {
+export default function VChart({ data, stream, startDate, endDate, onResampleChange }) {
   const { leftYMin, leftYMax, leftYStep, rightYMin, rightYMax, rightYStep } = getAxisBoundsAndStepValues(
     data.datasets.filter((_, i) => i % 2 == 0),
     data.datasets.filter((_, i) => i % 2 == 1),
     10,
     10,
   );
+  const nonStreamXDomain = getNonStreamTimeDomain(stream, startDate, endDate);
 
   const chartOptions = {
     maintainAspectRatio: false,
@@ -39,6 +41,7 @@ export default function VChart({ data, stream, onResampleChange }) {
             day: 'MM/dd',
           },
         },
+        ...nonStreamXDomain,
       },
       vAxis: {
         position: 'left',

--- a/frontend/src/charts/VwcChart/VwcChart.jsx
+++ b/frontend/src/charts/VwcChart/VwcChart.jsx
@@ -3,15 +3,17 @@ import { DateTime } from 'luxon';
 import PropTypes from 'prop-types';
 import { React } from 'react';
 import { getAxisBoundsAndStepValues } from '../alignAxis';
+import { getNonStreamTimeDomain } from '../timeDomain';
 import ChartWrapper from '../ChartWrapper';
 
-export default function VwcChart({ data, stream, onResampleChange }) {
+export default function VwcChart({ data, stream, startDate, endDate, onResampleChange }) {
   const { leftYMin, leftYMax, leftYStep, rightYMin, rightYMax, rightYStep } = getAxisBoundsAndStepValues(
     data.datasets.filter((_, i) => i % 2 == 0),
     data.datasets.filter((_, i) => i % 2 == 1),
     10,
     10,
   );
+  const nonStreamXDomain = getNonStreamTimeDomain(stream, startDate, endDate);
 
   const chartOptions = {
     maintainAspectRatio: false,
@@ -39,6 +41,7 @@ export default function VwcChart({ data, stream, onResampleChange }) {
             day: 'MM/dd',
           },
         },
+        ...nonStreamXDomain,
       },
       ecAxis: {
         type: 'linear',

--- a/frontend/src/charts/__tests__/ChartTimeDomain.test.jsx
+++ b/frontend/src/charts/__tests__/ChartTimeDomain.test.jsx
@@ -1,0 +1,148 @@
+import { describe, it, expect } from 'vitest';
+import React from 'react';
+import { render, screen } from '@testing-library/react';
+import { DateTime } from 'luxon';
+import { Chart as ChartJS } from 'chart.js';
+import VChart from '../VChart/VChart';
+import VwcChart from '../VwcChart/VwcChart';
+import PwrChart from '../PwrChart/PwrChart';
+import TempChart from '../TempChart/TempChart';
+import UniversalChart from '../UniversalChart';
+
+const startDate = DateTime.fromISO('2026-01-27T08:00:00.000Z');
+const endDate = DateTime.fromISO('2026-02-04T08:00:00.000Z');
+
+const vChartData = {
+  labels: [],
+  datasets: [
+    {
+      label: 'Voltage',
+      data: [
+        { x: 1769500800000, y: 3270 },
+        { x: 1769587200000, y: 3275 },
+      ],
+      yAxisID: 'vAxis',
+      borderColor: '#26C6DA',
+    },
+    {
+      label: 'Current',
+      data: [
+        { x: 1769500800000, y: 1.35 },
+        { x: 1769587200000, y: 1.4 },
+      ],
+      yAxisID: 'cAxis',
+      borderColor: '#112E51',
+    },
+  ],
+};
+
+const vwcChartData = {
+  labels: [],
+  datasets: [
+    {
+      label: 'VWC',
+      data: [
+        { x: 1769500800000, y: 3.12 },
+        { x: 1769587200000, y: 3.1 },
+      ],
+      yAxisID: 'vwcAxis',
+      borderColor: '#112E51',
+    },
+    {
+      label: 'EC',
+      data: [
+        { x: 1769500800000, y: 304 },
+        { x: 1769587200000, y: 303 },
+      ],
+      yAxisID: 'ecAxis',
+      borderColor: '#26C6DA',
+    },
+  ],
+};
+
+const singleAxisData = {
+  labels: [],
+  datasets: [
+    {
+      label: 'Single Axis',
+      data: [
+        { x: 1769500800000, y: 10 },
+        { x: 1769587200000, y: 12 },
+      ],
+      yAxisID: 'y',
+      borderColor: '#26C6DA',
+    },
+  ],
+};
+
+async function expectChartUsesSelectedTimeDomain() {
+  const chartElement = await screen.findByTestId('chart-container');
+  const chart = ChartJS.getChart(chartElement);
+  expect(chart.scales.x.min).toBe(startDate.toMillis());
+  expect(chart.scales.x.max).toBe(endDate.toMillis());
+}
+
+async function getRenderedChart() {
+  const chartElement = await screen.findByTestId('chart-container');
+  return ChartJS.getChart(chartElement);
+}
+
+describe('Chart Time Domain', () => {
+  it('pins non-stream VChart to selected start/end date', async () => {
+    render(<VChart data={vChartData} stream={false} startDate={startDate} endDate={endDate} />);
+    await expectChartUsesSelectedTimeDomain();
+  });
+
+  it('pins non-stream VwcChart to selected start/end date', async () => {
+    render(<VwcChart data={vwcChartData} stream={false} startDate={startDate} endDate={endDate} />);
+    await expectChartUsesSelectedTimeDomain();
+  });
+
+  it('pins non-stream PwrChart to selected start/end date', async () => {
+    render(<PwrChart data={singleAxisData} stream={false} startDate={startDate} endDate={endDate} />);
+    await expectChartUsesSelectedTimeDomain();
+  });
+
+  it('pins non-stream TempChart to selected start/end date', async () => {
+    render(<TempChart data={singleAxisData} stream={false} startDate={startDate} endDate={endDate} />);
+    await expectChartUsesSelectedTimeDomain();
+  });
+
+  it('pins non-stream UniversalChart to selected start/end date', async () => {
+    render(
+      <UniversalChart
+        data={singleAxisData}
+        stream={false}
+        chartId='universal-time-domain'
+        measurements={['temperature']}
+        units={['°C']}
+        axisIds={['y']}
+        startDate={startDate}
+        endDate={endDate}
+      />,
+    );
+    await expectChartUsesSelectedTimeDomain();
+  });
+
+  it('does not force min/max in stream mode', async () => {
+    render(<VChart data={vChartData} stream startDate={startDate} endDate={endDate} />);
+    const chart = await getRenderedChart();
+    expect(chart.config.options.scales.x.min).toBeUndefined();
+    expect(chart.config.options.scales.x.max).toBeUndefined();
+  });
+
+  it('falls back to auto domain when dates are invalid', async () => {
+    const invalidDate = DateTime.invalid('invalid range');
+    render(<PwrChart data={singleAxisData} stream={false} startDate={invalidDate} endDate={endDate} />);
+    const chart = await getRenderedChart();
+    expect(chart.config.options.scales.x.min).toBeUndefined();
+    expect(chart.config.options.scales.x.max).toBeUndefined();
+  });
+
+  it('normalizes reversed non-stream date ranges', async () => {
+    render(<TempChart data={singleAxisData} stream={false} startDate={endDate} endDate={startDate} />);
+    const chart = await getRenderedChart();
+    expect(chart.scales.x.min).toBe(startDate.toMillis());
+    expect(chart.scales.x.max).toBe(endDate.toMillis());
+  });
+});

--- a/frontend/src/charts/timeDomain.js
+++ b/frontend/src/charts/timeDomain.js
@@ -1,0 +1,32 @@
+export function getNonStreamTimeDomain(stream, startDate, endDate) {
+  if (stream) {
+    return {};
+  }
+
+  if (
+    !startDate ||
+    !endDate ||
+    typeof startDate.toMillis !== 'function' ||
+    typeof endDate.toMillis !== 'function'
+  ) {
+    return {};
+  }
+
+  if (typeof startDate.isValid === 'boolean' && !startDate.isValid) {
+    return {};
+  }
+  if (typeof endDate.isValid === 'boolean' && !endDate.isValid) {
+    return {};
+  }
+
+  const startMillis = startDate.toMillis();
+  const endMillis = endDate.toMillis();
+
+  if (!Number.isFinite(startMillis) || !Number.isFinite(endMillis)) {
+    return {};
+  }
+
+  return startMillis <= endMillis
+    ? { min: startMillis, max: endMillis }
+    : { min: endMillis, max: startMillis };
+}


### PR DESCRIPTION
## Description
Fixes chart time alignment in non-stream mode by forcing all charts to use the selected dashboard date range for the x-axis.

## Root Cause
Each chart was auto-scaling its x-axis to its own dataset extent.  
When datasets had different coverage, the same x-position mapped to different timestamps across charts.

## Closed Ticket: 
 #618 

## Dependencies
None.

## Changes
- Applied shared non-stream x-domain to:
  - `ENTS-backend/frontend/src/charts/VChart/VChart.jsx`
  - `/ENTS-backend/frontend/src/charts/VwcChart/VwcChart.jsx`
  - `/ENTS-backend/frontend/src/charts/PwrChart/PwrChart.jsx`
  - `/ENTS-backend/frontend/src/charts/TempChart/TempChart.jsx`
  - `/ENTS-backend/frontend/src/charts/UniversalChart.jsx`
- Added helper:
  - `/ENTS-backend/frontend/src/charts/timeDomain.js`
- Helper behavior:
  - applies only in non-stream mode
  - ignores invalid/missing dates (falls back to auto-domain)
  - normalizes reversed ranges (`startDate > endDate`)

## Testing
Added:
- `/ENTS-backend/frontend/src/charts/__tests__/ChartTimeDomain.test.jsx`

Coverage:
- non-stream x-domain pinning for all affected chart components
- stream mode does not force x min/max
- invalid date fallback
- reversed range normalization

Local results:
- `npx vitest run src/charts/__tests__/ChartTimeDomain.test.jsx` → 8 passed
- `npx eslint` on updated files → passed

## Screenshots 
<img width="1440" height="860" alt="Screenshot 2026-02-18 at 11 59 18 PM" src="https://github.com/user-attachments/assets/3c48d2eb-24eb-4e30-8c8b-c71de432fe99" />
<img width="1438" height="855" alt="Screenshot 2026-02-19 at 12 00 01 AM" src="https://github.com/user-attachments/assets/c449875e-d03e-402a-b532-d2ea557261d0" />


## Notes (optional)
Stream behavior is unchanged by design.
