### PR TITLE
Added marshmallow try/except statements for getting data

### DIFF
--- a/backend/api/resources/power_data.py
+++ b/backend/api/resources/power_data.py
@@ -1,5 +1,6 @@
 from flask import request, jsonify
 from flask_restful import Resource
+from marshmallow.exceptions import ValidationError
 from ..schemas.power_data_schema import PowerDataSchema
 from ..schemas.get_cell_data_schema import GetCellDataSchema
 from ..schemas.p_input import PInput
@@ -27,7 +28,11 @@ class Power_Data(Resource):
         return power_schema.jsonify(new_pwr_data)
 
     def get(self, cell_id=0):
-        v_args = get_cell_data.load(request.args)
+        try:
+            v_args = get_cell_data.load(request.args)
+        except ValidationError as _:
+            return jsonify({"errors": "Invalid request arguments."}), 400
+
         stream = v_args["stream"] if "stream" in v_args else False
         return jsonify(
             PowerData.get_power_data_obj(

--- a/backend/api/resources/sensor_data.py
+++ b/backend/api/resources/sensor_data.py
@@ -30,6 +30,7 @@ import base64
 
 from flask import request, jsonify, Response
 from flask_restful import Resource
+from marshmallow.exceptions import ValidationError
 
 from .util import process_measurement, process_generic_measurement
 
@@ -44,7 +45,11 @@ class SensorData(Resource):
         """Gets specified sensor data"""
 
         # get args
-        v_args = self.get_sensor_data_schema.load(request.args)
+        try:
+            v_args = self.get_sensor_data_schema.load(request.args)
+        except ValidationError as _:
+            return jsonify({"errors": "Invalid request arguments."}), 400
+
         stream = v_args.get("stream", False)
         resample = v_args.get("resample", "hour")
 

--- a/backend/api/resources/teros_data.py
+++ b/backend/api/resources/teros_data.py
@@ -1,5 +1,6 @@
 from flask import request, jsonify
 from flask_restful import Resource
+from marshmallow.exceptions import ValidationError
 from ..schemas.teros_data_schema import TEROSDataSchema
 from ..schemas.get_cell_data_schema import GetCellDataSchema
 from ..schemas.t_input import TInput
@@ -29,7 +30,12 @@ class Teros_Data(Resource):
         return teros_schema.jsonify(new_teros_data)
 
     def get(self, cell_id=0):
-        v_args = get_cell_data.load(request.args)
+        try:
+            v_args = get_cell_data.load(request.args)
+        except ValidationError as _:
+            return jsonify({"errors": "Invalid request arguments."}), 400
+
+
         stream = v_args["stream"] if "stream" in v_args else False
         return jsonify(
             TEROSData.get_teros_data_obj(


### PR DESCRIPTION
*In progress*: need to resolve this error. Don't know why there's another error happening. 

```
backend-1  | 2026-03-03T00:19:17.921560832Z [2026-03-03 00:19:17 +0000] [6] [ERROR] Error handling request /api/power/1?startTime=2026-01-16T06:38.818-08:00&endTime=2026-03-02T16:06:38.818-08:00&resample=hour
backend-1  | 2026-03-03T00:19:17.921606955Z Traceback (most recent call last):
backend-1  | 2026-03-03T00:19:17.921617290Z   File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/base_async.py", line 68, in handle
backend-1  | 2026-03-03T00:19:17.921626434Z     self.handle_request(listener_name, req, client, addr)
backend-1  | 2026-03-03T00:19:17.921634205Z   File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/ggevent.py", line 124, in handle_request
backend-1  | 2026-03-03T00:19:17.921642364Z     super().handle_request(listener_name, req, sock, addr)
backend-1  | 2026-03-03T00:19:17.921649947Z   File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/base_async.py", line 217, in handle_request
backend-1  | 2026-03-03T00:19:17.921657856Z     respiter = self.wsgi(environ, resp.start_response)
backend-1  | 2026-03-03T00:19:17.921665335Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921672834Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1498, in __call__
backend-1  | 2026-03-03T00:19:17.921680777Z     return self.wsgi_app(environ, start_response)
backend-1  | 2026-03-03T00:19:17.921688393Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921695908Z   File "/usr/local/lib/python3.11/site-packages/flask_socketio/__init__.py", line 42, in __call__
backend-1  | 2026-03-03T00:19:17.921703635Z     return super().__call__(environ, start_response)
backend-1  | 2026-03-03T00:19:17.921711191Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921718643Z   File "/usr/local/lib/python3.11/site-packages/engineio/middleware.py", line 74, in __call__
backend-1  | 2026-03-03T00:19:17.921726438Z     return self.wsgi_app(environ, start_response)
backend-1  | 2026-03-03T00:19:17.921734051Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921742081Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1476, in wsgi_app
backend-1  | 2026-03-03T00:19:17.921750008Z     response = self.handle_exception(e)
backend-1  | 2026-03-03T00:19:17.921757111Z                ^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921764819Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 298, in error_router
backend-1  | 2026-03-03T00:19:17.921772801Z     return original_handler(e)
backend-1  | 2026-03-03T00:19:17.921780842Z            ^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921806141Z   File "/usr/local/lib/python3.11/site-packages/flask_cors/extension.py", line 176, in wrapped_function
backend-1  | 2026-03-03T00:19:17.921814015Z     return cors_after_request(app.make_response(f(*args, **kwargs)))
backend-1  | 2026-03-03T00:19:17.921820251Z                                                 ^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921826543Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 295, in error_router
backend-1  | 2026-03-03T00:19:17.921832777Z     return self.handle_error(e)
backend-1  | 2026-03-03T00:19:17.921840365Z            ^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921846257Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 310, in handle_error
backend-1  | 2026-03-03T00:19:17.921852532Z     _handle_flask_propagate_exceptions_config(current_app, e)
backend-1  | 2026-03-03T00:19:17.921859360Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1473, in wsgi_app
backend-1  | 2026-03-03T00:19:17.921865709Z     response = self.full_dispatch_request()
backend-1  | 2026-03-03T00:19:17.921871574Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921877673Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 882, in full_dispatch_request
backend-1  | 2026-03-03T00:19:17.921884011Z     rv = self.handle_user_exception(e)
backend-1  | 2026-03-03T00:19:17.921889762Z          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921895496Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 298, in error_router
backend-1  | 2026-03-03T00:19:17.921901778Z     return original_handler(e)
backend-1  | 2026-03-03T00:19:17.921907482Z            ^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921913519Z   File "/usr/local/lib/python3.11/site-packages/flask_cors/extension.py", line 176, in wrapped_function
backend-1  | 2026-03-03T00:19:17.921919795Z     return cors_after_request(app.make_response(f(*args, **kwargs)))
backend-1  | 2026-03-03T00:19:17.921926090Z                                                 ^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921932347Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 295, in error_router
backend-1  | 2026-03-03T00:19:17.921938615Z     return self.handle_error(e)
backend-1  | 2026-03-03T00:19:17.921944485Z            ^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921950283Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 310, in handle_error
backend-1  | 2026-03-03T00:19:17.921956688Z     _handle_flask_propagate_exceptions_config(current_app, e)
backend-1  | 2026-03-03T00:19:17.921962818Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 880, in full_dispatch_request
backend-1  | 2026-03-03T00:19:17.921969372Z     rv = self.dispatch_request()
backend-1  | 2026-03-03T00:19:17.921976716Z          ^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.921983146Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 865, in dispatch_request
backend-1  | 2026-03-03T00:19:17.921989617Z     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
backend-1  | 2026-03-03T00:19:17.922002642Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.922009124Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 493, in wrapper
backend-1  | 2026-03-03T00:19:17.922015906Z     return self.make_response(data, code, headers=headers)
backend-1  | 2026-03-03T00:19:17.922022709Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.922028807Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 522, in make_response
backend-1  | 2026-03-03T00:19:17.922035806Z     resp = self.representations[mediatype](data, *args, **kwargs)
backend-1  | 2026-03-03T00:19:17.922041940Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.922047728Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/representations/json.py", line 21, in output_json
backend-1  | 2026-03-03T00:19:17.922054713Z     dumped = dumps(data, **settings) + "\n"
backend-1  | 2026-03-03T00:19:17.922061448Z              ^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.922067129Z   File "/usr/local/lib/python3.11/json/__init__.py", line 238, in dumps
backend-1  | 2026-03-03T00:19:17.922073076Z     **kw).encode(obj)
backend-1  | 2026-03-03T00:19:17.922078873Z           ^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.922084651Z   File "/usr/local/lib/python3.11/json/encoder.py", line 202, in encode
backend-1  | 2026-03-03T00:19:17.922091734Z     chunks = list(chunks)
backend-1  | 2026-03-03T00:19:17.922097863Z              ^^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.922103883Z   File "/usr/local/lib/python3.11/json/encoder.py", line 439, in _iterencode
backend-1  | 2026-03-03T00:19:17.922110403Z     o = _default(o)
backend-1  | 2026-03-03T00:19:17.922116034Z         ^^^^^^^^^^^
backend-1  | 2026-03-03T00:19:17.922121747Z   File "/usr/local/lib/python3.11/json/encoder.py", line 180, in default
backend-1  | 2026-03-03T00:19:17.922128833Z     raise TypeError(f'Object of type {o.__class__.__name__} '
backend-1  | 2026-03-03T00:19:17.922136617Z TypeError: Object of type Response is not JSON serializable
```

When validating HTTP request arguments, added a try/except statement to check for validity from marshmallow. Returns a 400 error if there is an exception and returns the error code.

http://localhost:3000/api/sensor/?name=TEROS12_TEMP&cellId=2&measurement=Temperature&startTime=2026-01-19T12:00.000-08:00&endTime=2026-01-21T20:42:25.000-08:00&resample=hour

Example error output
```
backend-1  | 2026-03-02T23:43:18.067389678Z [2026-03-02 23:43:18 +0000] [8] [ERROR] Error handling request /api/sensor/?name=TEROS12_TEMP&cellId=2&measurement=Temperature&startTime=2026-01-19T12:00.000-08:00&endTime=2026-01-21T20:42:25.000-08:00&resample=hour
backend-1  | 2026-03-02T23:43:18.067506281Z Traceback (most recent call last):
backend-1  | 2026-03-02T23:43:18.067529661Z   File "/api/resources/sensor_data.py", line 49, in get
backend-1  | 2026-03-02T23:43:18.067548055Z     v_args = self.get_sensor_data_schema.load(request.args)
backend-1  | 2026-03-02T23:43:18.067562795Z              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.067576227Z   File "/usr/local/lib/python3.11/site-packages/marshmallow_sqlalchemy/load_instance_mixin.py", line 149, in load
backend-1  | 2026-03-02T23:43:18.067620887Z     return cast("ma.Schema", super()).load(_cast_data(data), **kwargs)
backend-1  | 2026-03-02T23:43:18.067635369Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.067648175Z   File "/usr/local/lib/python3.11/site-packages/marshmallow/schema.py", line 792, in load
backend-1  | 2026-03-02T23:43:18.067662991Z     return self._do_load(
backend-1  | 2026-03-02T23:43:18.067677584Z            ^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.067690273Z   File "/usr/local/lib/python3.11/site-packages/marshmallow/schema.py", line 999, in _do_load
backend-1  | 2026-03-02T23:43:18.067704089Z     raise exc
backend-1  | 2026-03-02T23:43:18.067715714Z marshmallow.exceptions.ValidationError: {'startTime': ['Not a valid datetime.']}
backend-1  | 2026-03-02T23:43:18.067728556Z 
backend-1  | 2026-03-02T23:43:18.067740956Z During handling of the above exception, another exception occurred:
backend-1  | 2026-03-02T23:43:18.067753991Z 
backend-1  | 2026-03-02T23:43:18.067766434Z Traceback (most recent call last):
backend-1  | 2026-03-02T23:43:18.067779203Z   File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/base_async.py", line 68, in handle
backend-1  | 2026-03-02T23:43:18.067794575Z     self.handle_request(listener_name, req, client, addr)
backend-1  | 2026-03-02T23:43:18.067808908Z   File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/ggevent.py", line 124, in handle_request
backend-1  | 2026-03-02T23:43:18.067823307Z     super().handle_request(listener_name, req, sock, addr)
backend-1  | 2026-03-02T23:43:18.067837237Z   File "/usr/local/lib/python3.11/site-packages/gunicorn/workers/base_async.py", line 217, in handle_request
backend-1  | 2026-03-02T23:43:18.067851969Z     respiter = self.wsgi(environ, resp.start_response)
backend-1  | 2026-03-02T23:43:18.067865525Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.067878950Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1498, in __call__
backend-1  | 2026-03-02T23:43:18.067894668Z     return self.wsgi_app(environ, start_response)
backend-1  | 2026-03-02T23:43:18.067907984Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.067921203Z   File "/usr/local/lib/python3.11/site-packages/flask_socketio/__init__.py", line 42, in __call__
backend-1  | 2026-03-02T23:43:18.067936546Z     return super().__call__(environ, start_response)
backend-1  | 2026-03-02T23:43:18.067954167Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.067967958Z   File "/usr/local/lib/python3.11/site-packages/engineio/middleware.py", line 74, in __call__
backend-1  | 2026-03-02T23:43:18.068002659Z     return self.wsgi_app(environ, start_response)
backend-1  | 2026-03-02T23:43:18.068016858Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068030334Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1476, in wsgi_app
backend-1  | 2026-03-02T23:43:18.068045016Z     response = self.handle_exception(e)
backend-1  | 2026-03-02T23:43:18.068059262Z                ^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068072529Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 298, in error_router
backend-1  | 2026-03-02T23:43:18.068087576Z     return original_handler(e)
backend-1  | 2026-03-02T23:43:18.068100790Z            ^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068114507Z   File "/usr/local/lib/python3.11/site-packages/flask_cors/extension.py", line 176, in wrapped_function
backend-1  | 2026-03-02T23:43:18.068129624Z     return cors_after_request(app.make_response(f(*args, **kwargs)))
backend-1  | 2026-03-02T23:43:18.068144972Z                                                 ^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068159066Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 295, in error_router
backend-1  | 2026-03-02T23:43:18.068175140Z     return self.handle_error(e)
backend-1  | 2026-03-02T23:43:18.068188743Z            ^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068203097Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 310, in handle_error
backend-1  | 2026-03-02T23:43:18.068217802Z     _handle_flask_propagate_exceptions_config(current_app, e)
backend-1  | 2026-03-02T23:43:18.068231421Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 1473, in wsgi_app
backend-1  | 2026-03-02T23:43:18.068245326Z     response = self.full_dispatch_request()
backend-1  | 2026-03-02T23:43:18.068260164Z                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068273748Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 882, in full_dispatch_request
backend-1  | 2026-03-02T23:43:18.068287996Z     rv = self.handle_user_exception(e)
backend-1  | 2026-03-02T23:43:18.068302543Z          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068316455Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 298, in error_router
backend-1  | 2026-03-02T23:43:18.068383903Z     return original_handler(e)
backend-1  | 2026-03-02T23:43:18.068399543Z            ^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068411718Z   File "/usr/local/lib/python3.11/site-packages/flask_cors/extension.py", line 176, in wrapped_function
backend-1  | 2026-03-02T23:43:18.068425969Z     return cors_after_request(app.make_response(f(*args, **kwargs)))
backend-1  | 2026-03-02T23:43:18.068440202Z                                                 ^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068453783Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 295, in error_router
backend-1  | 2026-03-02T23:43:18.068468014Z     return self.handle_error(e)
backend-1  | 2026-03-02T23:43:18.068497832Z            ^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068515609Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 310, in handle_error
backend-1  | 2026-03-02T23:43:18.068530356Z     _handle_flask_propagate_exceptions_config(current_app, e)
backend-1  | 2026-03-02T23:43:18.068543955Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 880, in full_dispatch_request
backend-1  | 2026-03-02T23:43:18.068558511Z     rv = self.dispatch_request()
backend-1  | 2026-03-02T23:43:18.068622473Z          ^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068637651Z   File "/usr/local/lib/python3.11/site-packages/flask/app.py", line 865, in dispatch_request
backend-1  | 2026-03-02T23:43:18.068654497Z     return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
backend-1  | 2026-03-02T23:43:18.068668822Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068683654Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 489, in wrapper
backend-1  | 2026-03-02T23:43:18.068697936Z     resp = resource(*args, **kwargs)
backend-1  | 2026-03-02T23:43:18.068712520Z            ^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068725795Z   File "/usr/local/lib/python3.11/site-packages/flask/views.py", line 110, in view
backend-1  | 2026-03-02T23:43:18.068740347Z     return current_app.ensure_sync(self.dispatch_request)(**kwargs)  # type: ignore[no-any-return]
backend-1  | 2026-03-02T23:43:18.068754395Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068768090Z   File "/usr/local/lib/python3.11/site-packages/flask_restful/__init__.py", line 604, in dispatch_request
backend-1  | 2026-03-02T23:43:18.068782411Z     resp = meth(*args, **kwargs)
backend-1  | 2026-03-02T23:43:18.068796113Z            ^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068809877Z   File "/api/resources/sensor_data.py", line 51, in get
backend-1  | 2026-03-02T23:43:18.068824364Z     return jsonify({f"Invalid request arguments. {e}"}), 400
backend-1  | 2026-03-02T23:43:18.068838286Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068852482Z   File "/usr/local/lib/python3.11/site-packages/flask/json/__init__.py", line 170, in jsonify
backend-1  | 2026-03-02T23:43:18.068866661Z     return current_app.json.response(*args, **kwargs)  # type: ignore[return-value]
backend-1  | 2026-03-02T23:43:18.068881483Z            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068895259Z   File "/usr/local/lib/python3.11/site-packages/flask/json/provider.py", line 214, in response
backend-1  | 2026-03-02T23:43:18.068909772Z     f"{self.dumps(obj, **dump_args)}\n", mimetype=self.mimetype
backend-1  | 2026-03-02T23:43:18.068925845Z        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068939568Z   File "/usr/local/lib/python3.11/site-packages/flask/json/provider.py", line 179, in dumps
backend-1  | 2026-03-02T23:43:18.068953765Z     return json.dumps(obj, **kwargs)
backend-1  | 2026-03-02T23:43:18.068967203Z            ^^^^^^^^^^^^^^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.068994410Z   File "/usr/local/lib/python3.11/json/__init__.py", line 238, in dumps
backend-1  | 2026-03-02T23:43:18.069009120Z     **kw).encode(obj)
backend-1  | 2026-03-02T23:43:18.069024343Z           ^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.069037564Z   File "/usr/local/lib/python3.11/json/encoder.py", line 202, in encode
backend-1  | 2026-03-02T23:43:18.069051512Z     chunks = list(chunks)
backend-1  | 2026-03-02T23:43:18.069065407Z              ^^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.069079479Z   File "/usr/local/lib/python3.11/json/encoder.py", line 439, in _iterencode
backend-1  | 2026-03-02T23:43:18.069093804Z     o = _default(o)
backend-1  | 2026-03-02T23:43:18.069106777Z         ^^^^^^^^^^^
backend-1  | 2026-03-02T23:43:18.069119681Z   File "/usr/local/lib/python3.11/site-packages/flask/json/provider.py", line 121, in _default
backend-1  | 2026-03-02T23:43:18.069133965Z     raise TypeError(f"Object of type {type(o).__name__} is not JSON serializable")
backend-1  | 2026-03-02T23:43:18.069148207Z TypeError: Object of type set is not JSON serializable
```