### PR TITLE
fix(docker): route gunicorn worker temp to shared memory to resolve permission denied

### DIFF
--- a/backend/entrypoint.sh
+++ b/backend/entrypoint.sh
@@ -9,7 +9,7 @@ do
             flask --app wsgi --debug run -h 0.0.0.0 -p 8000;;
         p) 
             echo "Running Gunicorn with gevent"
-            exec gunicorn -c gunicorn.conf.py -w 1 wsgi:handler;;
+            exec gunicorn --worker-tmp-dir /dev/shm -c gunicorn.conf.py -w 1 wsgi:handler;;
         w) 
             case "$OPTARG" in
                 dev)

--- a/backend/gunicorn.conf.py
+++ b/backend/gunicorn.conf.py
@@ -10,6 +10,7 @@ bind = "0.0.0.0:8000"
 workers = multiprocessing.cpu_count() * 2 + 1
 worker_class = "gevent"
 worker_connections = 1000
+worker_tmp_dir = "/dev/shm"
 
 # Additional settings for Socket.IO
 keepalive = 2


### PR DESCRIPTION
Closes #670

### Summary
This PR fixes the `[Errno 13] Permission denied` control server crash that occurs during local backend startup via Docker. The error happens because Gunicorn attempts to write worker heartbeat files to a restricted disk directory, which can be blocked by strict host OS profiles (e.g., Arch Linux, SELinux/AppArmor) or UID/GID mapping issues in rootless Docker setups.

### Changes
* Updated `backend/entrypoint.sh` to explicitly pass the `--worker-tmp-dir /dev/shm` flag to the Gunicorn execution command.
* Updated `backend/gunicorn.conf.py` to include `worker_tmp_dir = "/dev/shm"` to ensure the configuration is caught globally.

### Result
Gunicorn workers now securely use the container's shared memory (`/dev/shm`) instead of the disk-backed `/tmp` directory. This bypasses host-level permission blocks and allows the background worker processes to boot successfully. 

### Testing
* Ran the standard `docker compose down && docker compose up --build -d` workflow locally.
* Verified in the logs that the `[Errno 13] Permission denied` error no longer crashes the `gevent` worker process.
* **Note to maintainers:** While the Gunicorn worker boot issue is fully resolved, the `main` branch currently fails immediately afterward on my end due to an unrelated SQLAlchemy `InvalidRequestError` (Specifically: `expression 'User' failed to locate a name` in `api.models.cell.Cell`). I am submitting this DevOps fix first to keep PRs scoped before looking into the Python models.

Closes #670 