### PR TITLE
feat: add cell name search to GET /api/cell/ endpoint

### DIFF
--- a/backend/api/models/cell.py
+++ b/backend/api/models/cell.py
@@ -1,6 +1,5 @@
 from ..models import db
 
-
 """"This is the reference; we stole this from commenter
 https://stackoverflow.com/questions/5756559/how-to-build-many-to-many-relations-using-sqlalchemy-a-good-example"""
 
@@ -80,6 +79,10 @@ class Cell(db.Model):
     @staticmethod
     def find_by_name(name):
         return Cell.query.filter_by(name=name).first()
+
+    @staticmethod
+    def search_by_name(pattern):
+        return Cell.query.filter(Cell.name.ilike(f"%{pattern}%")).all()
 
     @staticmethod
     def get_cells_by_user_id(id):

--- a/backend/api/resources/cell.py
+++ b/backend/api/resources/cell.py
@@ -25,9 +25,12 @@ class Cell(Resource):
         userCells = json_data.get("user")
         tag_ids = json_data.get("tags")  # Comma-separated tag IDs: "1,2,3"
         category = json_data.get("category")  # Filter by tag category
+        name = json_data.get("name")  # Search by name substring
 
         # Base query
-        if userCells:
+        if name:
+            cells = CellModel.search_by_name(name)
+        elif userCells:
             cells = CellModel.get_cells_by_user_id(user.id)
         else:
             cells = CellModel.get_all()

--- a/backend/tests/test_cell.py
+++ b/backend/tests/test_cell.py
@@ -1,4 +1,22 @@
 from api.models.user import User
+from api.models.cell import Cell
+
+
+def test_cell_search_by_name(setup_cells):
+    """
+    GIVEN cells exist in the database
+    WHEN searching cells by name pattern
+    THEN only cells whose names match the pattern are returned
+    """
+    results = Cell.search_by_name("cell")
+    assert len(results) == 2
+
+    results = Cell.search_by_name("cell_1")
+    assert len(results) == 1
+    assert results[0].name == "cell_1"
+
+    results = Cell.search_by_name("nonexistent")
+    assert len(results) == 0
 
 
 def test_cell_post_returns_id_and_name(init_database):


### PR DESCRIPTION
Fixes #527

## Summary

Adds case-insensitive substring search for cells by name via the existing `GET /api/cell/` endpoint.

## Changes

- **`Cell.search_by_name(pattern)`** — new static method on the `Cell` model using SQLAlchemy `ilike` for case-insensitive matching (same pattern as `Tag.search_by_name`)
- **`GET /api/cell/?name=<query>`** — when `name` param is provided, returns cells whose names contain the given string (case-insensitive)
- **Test** — added `test_cell_search_by_name` covering full match, partial match, and no match cases

## Usage

```http
GET /api/cell/?name=station
