### PR TITLE
Fix gunicron import errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ When adding a new entry, please use the following format:
 
 ## Log
 
+- [2026-03-10] hotfix: Fixed import errors [#697](https://github.com/jlab-sensing/ENTS-backend/pull/697)
 - [2026-03-05] chore: remove deprecated import_example_data script and update docs to use ents CLI [#665](https://github.com/jlab-sensing/ENTS-backend/pull/665)
 - [2026-03-05] fix: Temp removed "Export to CSV option" hotfix [#671](https://github.com/jlab-sensing/ENTS-backend/pull/671)

--- a/backend/api/migrations/versions/15816217ea64_added_indexes_for_timestamps.py
+++ b/backend/api/migrations/versions/15816217ea64_added_indexes_for_timestamps.py
@@ -9,7 +9,6 @@ Create Date: 2024-05-20 12:02:37.695736
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "15816217ea64"
 down_revision = "2c563dcd2920"

--- a/backend/api/migrations/versions/2c563dcd2920_fixed_data_sensor_id_fk_to_sensor_id.py
+++ b/backend/api/migrations/versions/2c563dcd2920_fixed_data_sensor_id_fk_to_sensor_id.py
@@ -9,7 +9,6 @@ Create Date: 2024-04-20 00:32:40.589573
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "2c563dcd2920"
 down_revision = "f44a21ea53a4"

--- a/backend/api/migrations/versions/47822a5f0b44_added_user_cell_table.py
+++ b/backend/api/migrations/versions/47822a5f0b44_added_user_cell_table.py
@@ -10,7 +10,6 @@ from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
-
 # revision identifiers, used by Alembic.
 revision = "47822a5f0b44"
 down_revision = "d09945f167e5"

--- a/backend/api/migrations/versions/535eee3c4ba5_added_unique_constraint_for_cell_logger.py
+++ b/backend/api/migrations/versions/535eee3c4ba5_added_unique_constraint_for_cell_logger.py
@@ -9,7 +9,6 @@ Create Date: 2022-08-09 14:30:23.059143
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "535eee3c4ba5"
 down_revision = "7f24337773d6"

--- a/backend/api/migrations/versions/596bac7fbbee_added_tags.py
+++ b/backend/api/migrations/versions/596bac7fbbee_added_tags.py
@@ -9,7 +9,6 @@ Create Date: 2025-01-21 17:30:36.277304
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "596bac7fbbee"
 down_revision = "76c91a8730cb"

--- a/backend/api/migrations/versions/74f0f195babd_added_sensor_and_data_tables.py
+++ b/backend/api/migrations/versions/74f0f195babd_added_sensor_and_data_tables.py
@@ -9,7 +9,6 @@ Create Date: 2024-01-19 12:36:13.616466
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "74f0f195babd"
 down_revision = "c7c5894af080"

--- a/backend/api/migrations/versions/76c91a8730cb_added_archive_boolean_to_cell.py
+++ b/backend/api/migrations/versions/76c91a8730cb_added_archive_boolean_to_cell.py
@@ -9,7 +9,6 @@ Create Date: 2024-06-24 14:52:26.255431
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "76c91a8730cb"
 down_revision = "caf4baaaa14f"

--- a/backend/api/migrations/versions/7f24337773d6_added_cascading_delete_for_cell_foreign_.py
+++ b/backend/api/migrations/versions/7f24337773d6_added_cascading_delete_for_cell_foreign_.py
@@ -9,7 +9,6 @@ Create Date: 2022-08-09 13:54:45.763913
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "7f24337773d6"
 down_revision = "19d307d816a1"

--- a/backend/api/migrations/versions/8ec092613768_changed_current_and_voltage_to_floats.py
+++ b/backend/api/migrations/versions/8ec092613768_changed_current_and_voltage_to_floats.py
@@ -9,7 +9,6 @@ Create Date: 2023-06-05 13:02:55.326164
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "8ec092613768"
 down_revision = "c751acdaab3f"

--- a/backend/api/migrations/versions/94004fb2d7c4_backfill_cell_user_with_creators.py
+++ b/backend/api/migrations/versions/94004fb2d7c4_backfill_cell_user_with_creators.py
@@ -9,7 +9,6 @@ Create Date: 2025-11-17 05:37:26.237380
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "94004fb2d7c4"
 down_revision = "47822a5f0b44"
@@ -20,8 +19,7 @@ depends_on = None
 def upgrade():
     # Backfill cell_user table with creators for all existing cells
     # This ensures that cell creators have access to their cells via the relationship
-    op.execute(
-        """
+    op.execute("""
         INSERT INTO cell_user (cell_id, user_id)
         SELECT c.id, c.user_id
         FROM cell c
@@ -30,20 +28,17 @@ def upgrade():
             SELECT 1 FROM cell_user cu
             WHERE cu.cell_id = c.id AND cu.user_id = c.user_id
         )
-    """
-    )
+    """)
 
 
 def downgrade():
     # Remove the backfilled creator relationships
     # This only removes entries where user_id matches the cell's creator
-    op.execute(
-        """
+    op.execute("""
         DELETE FROM cell_user
         WHERE (cell_id, user_id) IN (
             SELECT c.id, c.user_id
             FROM cell c
             WHERE c.user_id IS NOT NULL
         )
-    """
-    )
+    """)

--- a/backend/api/migrations/versions/a6d9c5f2e1b3_enforce_unique_logger_device_eui.py
+++ b/backend/api/migrations/versions/a6d9c5f2e1b3_enforce_unique_logger_device_eui.py
@@ -9,7 +9,6 @@ Create Date: 2026-02-16 14:22:00.000000
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "a6d9c5f2e1b3"
 down_revision = "94004fb2d7c4"
@@ -21,20 +20,14 @@ def upgrade():
     bind = op.get_bind()
 
     # Normalize values so uniqueness is based on meaningful content.
-    bind.execute(
-        sa.text(
-            """
+    bind.execute(sa.text("""
             UPDATE logger
             SET device_eui = NULLIF(TRIM(device_eui), '')
             WHERE device_eui IS NOT NULL
-            """
-        )
-    )
+            """))
 
     # Stop if duplicates exist so data can be cleaned intentionally.
-    duplicates = bind.execute(
-        sa.text(
-            """
+    duplicates = bind.execute(sa.text("""
             SELECT UPPER(TRIM(device_eui)) AS normalized_device_eui, COUNT(*) AS cnt
             FROM logger
             WHERE device_eui IS NOT NULL AND TRIM(device_eui) <> ''
@@ -42,9 +35,7 @@ def upgrade():
             HAVING COUNT(*) > 1
             ORDER BY cnt DESC, normalized_device_eui
             LIMIT 5
-            """
-        )
-    ).fetchall()
+            """)).fetchall()
 
     if duplicates:
         duplicate_summary = ", ".join(f"{row[0]} ({row[1]})" for row in duplicates)
@@ -53,15 +44,11 @@ def upgrade():
             f"{duplicate_summary}"
         )
 
-    op.execute(
-        sa.text(
-            """
+    op.execute(sa.text("""
             CREATE UNIQUE INDEX uq_logger_device_eui_norm
             ON logger (UPPER(TRIM(device_eui)))
             WHERE device_eui IS NOT NULL AND TRIM(device_eui) <> ''
-            """
-        )
-    )
+            """))
 
 
 def downgrade():

--- a/backend/api/migrations/versions/c098fa612f87_added_index_to_power_data_and_teros.py
+++ b/backend/api/migrations/versions/c098fa612f87_added_index_to_power_data_and_teros.py
@@ -9,7 +9,6 @@ Create Date: 2025-07-29 21:25:53.921482
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "c098fa612f87"
 down_revision = "596bac7fbbee"

--- a/backend/api/migrations/versions/c751acdaab3f_added_water_potential_and_raw_.py
+++ b/backend/api/migrations/versions/c751acdaab3f_added_water_potential_and_raw_.py
@@ -9,7 +9,6 @@ Create Date: 2023-06-02 15:38:36.412041
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "c751acdaab3f"
 down_revision = "88337765ad01"

--- a/backend/api/migrations/versions/c7c5894af080_added_location_long_lat_to_cell.py
+++ b/backend/api/migrations/versions/c7c5894af080_added_location_long_lat_to_cell.py
@@ -9,7 +9,6 @@ Create Date: 2023-10-12 17:13:35.041417
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "c7c5894af080"
 down_revision = "8ec092613768"

--- a/backend/api/migrations/versions/caf4baaaa14f_added_user_id_integer_field_to_cell.py
+++ b/backend/api/migrations/versions/caf4baaaa14f_added_user_id_integer_field_to_cell.py
@@ -9,7 +9,6 @@ Create Date: 2024-05-30 01:45:16.100418
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "caf4baaaa14f"
 down_revision = "15816217ea64"

--- a/backend/api/migrations/versions/d09945f167e5_add_description_created_at_and_created_.py
+++ b/backend/api/migrations/versions/d09945f167e5_add_description_created_at_and_created_.py
@@ -9,7 +9,6 @@ Create Date: 2025-08-30 12:48:00.386352
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "d09945f167e5"
 down_revision = "fd48c93ccf7b"

--- a/backend/api/migrations/versions/eb87a7373607_added_user_and_token_tables.py
+++ b/backend/api/migrations/versions/eb87a7373607_added_user_and_token_tables.py
@@ -9,7 +9,6 @@ Create Date: 2024-01-22 23:29:48.128444
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "eb87a7373607"
 down_revision = "74f0f195babd"

--- a/backend/api/migrations/versions/f44a21ea53a4_added_updated_at_field_for_tokens.py
+++ b/backend/api/migrations/versions/f44a21ea53a4_added_updated_at_field_for_tokens.py
@@ -9,7 +9,6 @@ Create Date: 2024-02-03 21:50:51.468259
 from alembic import op
 import sqlalchemy as sa
 
-
 # revision identifiers, used by Alembic.
 revision = "f44a21ea53a4"
 down_revision = "eb87a7373607"

--- a/backend/api/migrations/versions/fd48c93ccf7b_updated_loggers_for_ttn_registration.py
+++ b/backend/api/migrations/versions/fd48c93ccf7b_updated_loggers_for_ttn_registration.py
@@ -23,13 +23,11 @@ def upgrade():
     op.add_column("logger", sa.Column("uuid", sa.UUID(), nullable=True))
 
     # Generate unique UUIDs for existing rows
-    op.execute(
-        """
+    op.execute("""
         UPDATE logger 
         SET uuid = gen_random_uuid() 
         WHERE uuid IS NULL
-    """
-    )
+    """)
 
     # Now make the uuid column NOT NULL
     op.alter_column("logger", "uuid", nullable=False)
@@ -42,13 +40,11 @@ def upgrade():
     # Add date_created as nullable first
     op.add_column("logger", sa.Column("date_created", sa.DateTime(), nullable=True))
     # Set default date for existing rows
-    op.execute(
-        """
+    op.execute("""
         UPDATE logger 
         SET date_created = NOW() 
         WHERE date_created IS NULL
-    """
-    )
+    """)
     # Make it NOT NULL
     op.alter_column("logger", "date_created", nullable=False)
 

--- a/backend/api/resources/cell_data.py
+++ b/backend/api/resources/cell_data.py
@@ -2,6 +2,9 @@ from flask import request, jsonify
 from flask_restful import Resource
 import pandas as pd
 from ..schemas.get_cell_data_schema import GetCellDataSchema
+from ..models.power_data import PowerData
+from ..models.teros_data import TEROSData
+from ..models.sensor import Sensor
 from io import StringIO
 from celery import shared_task
 

--- a/backend/api/schemas/cell_schema.py
+++ b/backend/api/schemas/cell_schema.py
@@ -1,6 +1,5 @@
 from ..schemas import ma
 from ..models.cell import Cell
-from ..models.user import User  # noqa: F401 — must be registered before mapper configuration
 
 
 class CellSchema(ma.SQLAlchemyAutoSchema):


### PR DESCRIPTION
Fixes import errors that look like this. Caused by #671 

```
...
worker-1            |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/clsregistry.py", line 501, in _raise_for_name
worker-1            |     raise exc.InvalidRequestError(
worker-1            | sqlalchemy.exc.InvalidRequestError: When initializing mapper Mapper[Cell(cell)], expression 'User' failed to locate a name ('User'). If this is a class name, consider adding this relationship() to the <class 'api.models.cell.Cell'> class after both dependent classes have been defined.
```