### PR TITLE
Fix gunicron import errors.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,5 +10,6 @@ When adding a new entry, please use the following format:
 
 ## Log
 
+- [2026-03-10] hotfix: Fixed import errors [#698](https://github.com/jlab-sensing/ENTS-backend/pull/698)
 - [2026-03-05] chore: remove deprecated import_example_data script and update docs to use ents CLI [#665](https://github.com/jlab-sensing/ENTS-backend/pull/665)
 - [2026-03-05] fix: Temp removed "Export to CSV option" hotfix [#671](https://github.com/jlab-sensing/ENTS-backend/pull/671)

--- a/backend/api/resources/cell_data.py
+++ b/backend/api/resources/cell_data.py
@@ -2,8 +2,12 @@ from flask import request, jsonify
 from flask_restful import Resource
 import pandas as pd
 from ..schemas.get_cell_data_schema import GetCellDataSchema
+from ..models.power_data import PowerData  # noqa: F401
+from ..models.teros_data import TEROSData  # noqa: F401
+from ..models.sensor import Sensor  # noqa: F401
 from io import StringIO
 from celery import shared_task
+
 
 get_cell_data = GetCellDataSchema()
 


### PR DESCRIPTION
Fixes import errors that look like this. Caused by #671 

```
...
worker-1            |   File "/usr/local/lib/python3.11/site-packages/sqlalchemy/orm/clsregistry.py", line 501, in _raise_for_name
worker-1            |     raise exc.InvalidRequestError(
worker-1            | sqlalchemy.exc.InvalidRequestError: When initializing mapper Mapper[Cell(cell)], expression 'User' failed to locate a name ('User'). If this is a class name, consider adding this relationship() to the <class 'api.models.cell.Cell'> class after both dependent classes have been defined.
```