### PR TITLE
fix(frontend): implement dynamic Y-axis scaling for power charts (#723)

### DIFF
--- a/frontend/src/charts/UniversalChart.jsx
+++ b/frontend/src/charts/UniversalChart.jsx
@@ -7,8 +7,8 @@ import { getNonStreamTimeDomain } from './timeDomain';
 import ChartWrapper from './ChartWrapper';
 import { chartPlugins } from './plugins';
 import { getVwcAxisBounds } from './VwcChart/vwcAxis';
-
-export default function UniversalChart({ data, stream, chartId, measurements, units, axisIds, axisPolicy, startDate, endDate, onResampleChange }) {
+import { formatElectricalUnit, formatSensorValue } from "../pages/dashboard/components/unifiedChartUtils";
+export default function UniversalChart({ data, stream, chartId, sensorName, measurements, units, axisIds, axisPolicy, startDate, endDate, onResampleChange }) {
   // Build chart options dynamically based on measurements
   const buildChartOptions = () => {
     const nonStreamXDomain = getNonStreamTimeDomain(stream, startDate, endDate);
@@ -86,6 +86,13 @@ export default function UniversalChart({ data, stream, chartId, measurements, un
               max: leftYMax,
             }),
       };
+      scales.y.ticks = scales.y.ticks || {};
+      scales.y.ticks.callback = function(value) {
+        if (sensorName === 'POWER_VOLTAGE' || sensorName === 'POWER_CURRENT') {
+          return formatElectricalUnit(value, sensorName);
+        }
+        return value;
+      };
     }
     // Handle dual measurements (left and right axes)
     else if (measurements.length === 2) {
@@ -136,12 +143,33 @@ export default function UniversalChart({ data, stream, chartId, measurements, un
       };
     }
 
+    const activePlugins = measurements.length > 1 ? structuredClone(chartPlugins) : {};
+    
+    activePlugins.tooltip = {
+      callbacks: {
+        label: function(context) {
+          let label = context.dataset.label || '';
+          if (label) {
+            label += ': ';
+          }
+          if (context.parsed.y !== null) {
+            if (sensorName === 'POWER_VOLTAGE' || sensorName === 'POWER_CURRENT') {
+              label += formatElectricalUnit(context.parsed.y, sensorName);
+            } else {
+              label += context.parsed.y; // Default behavior for other sensors
+            }
+          }
+          return label;
+        }
+      }
+    };
+
     return {
       maintainAspectRatio: false,
       responsive: true,
       parsing: false,
       scales,
-      ...(measurements.length > 1 && { plugins: structuredClone(chartPlugins) }),
+      plugins: activePlugins,
     };
   };
 
@@ -160,6 +188,7 @@ UniversalChart.propTypes = {
   units: PropTypes.arrayOf(PropTypes.string).isRequired,
   axisIds: PropTypes.arrayOf(PropTypes.string).isRequired,
   axisPolicy: PropTypes.string,
+  sensorName: PropTypes.string,
   startDate: PropTypes.object,
   endDate: PropTypes.object,
   onResampleChange: PropTypes.func,

--- a/frontend/src/pages/dashboard/components/UnifiedChart.jsx
+++ b/frontend/src/pages/dashboard/components/UnifiedChart.jsx
@@ -14,14 +14,14 @@ const CHART_CONFIGS = {
   power_voltage: {
     sensor_name: 'POWER_VOLTAGE',
     measurements: ['Voltage'],
-    units: ['mV'],
+    units: ['V'],
     axisIds: ['y'],
     chartId: 'powerVoltage',
   },
   power_current: {
     sensor_name: 'POWER_CURRENT',
     measurements: ['Current'],
-    units: ['uA'],
+    units: ['A'],
     axisIds: ['y'],
     chartId: 'powerCurrent',
   },
@@ -443,6 +443,7 @@ function UnifiedChart({ type, cells, startDate, endDate, stream, liveData, proce
         data={sensorChartData}
         stream={stream}
         chartId={chartId}
+        sensorName={sensor_name}
         measurements={measurements}
         units={units}
         axisIds={axisIds}

--- a/frontend/src/pages/dashboard/components/unifiedChartUtils.js
+++ b/frontend/src/pages/dashboard/components/unifiedChartUtils.js
@@ -58,3 +58,48 @@ export function normalizeUnifiedStreamValue(sensorName, measurementLabel, value)
   }
   return value;
 }
+
+export const formatElectricalUnit = (value, type) => {
+  if (value === null || value === undefined) return 'N/A';
+
+  const absVal = Math.abs(value);
+
+  if (type === 'POWER_CURRENT') {
+    if (absVal < 0.001) return `${(value * 1000000).toFixed(3)} µA`;
+    if (absVal < 1) return `${(value * 1000).toFixed(3)} mA`;
+    return `${value.toFixed(3)} A`;
+  }
+
+  if (type === 'POWER_VOLTAGE') {
+    if (absVal < 1) return `${(value * 1000).toFixed(3)} mV`;
+    return `${value.toFixed(3)} V`;
+  }
+
+  return typeof value === 'number' ? value.toFixed(3) : value;
+};
+
+/**
+ * Dynamically scales and formats sensor values based on their magnitude.
+ * @param {number} value - The raw decimal value from the backend.
+ * @param {string} type - The sensor type (e.g., 'POWER_VOLTAGE', 'POWER_CURRENT').
+ * @returns {string} The formatted value with appropriate units.
+ */
+export const formatSensorValue = (value, type) => {
+  if (value === null || value === undefined) return '-';
+
+  const absValue = Math.abs(value);
+
+  if (type === 'POWER_CURRENT') {
+    if (absValue < 0.001) return `${(value * 1000000).toFixed(2)} µA`;
+    if (absValue < 1) return `${(value * 1000).toFixed(2)} mA`;
+    return `${value.toFixed(2)} A`;
+  }
+
+  if (type === 'POWER_VOLTAGE') {
+    if (absValue < 1) return `${(value * 1000).toFixed(2)} mV`;
+    return `${value.toFixed(2)} V`;
+  }
+
+  // Fallback for other sensor types (just limit decimals)
+  return typeof value === 'number' ? value.toFixed(2) : value;
+};


### PR DESCRIPTION
Fixes jlab-sensing/ENTS-node-firmware#326

## Changes Proposed:

- Created a pure utility function formatElectricalUnit to dynamically scale Voltage (V, mV) and Current (A, mA, µA) based on magnitude.

- Corrected the hardcoded base unit configurations in UnifiedChart.jsx from mV/uA to the standard V/A to reflect the raw STM32 firmware data.

- Injected the dynamic formatter into the Chart.js Y-axis tick callbacks and Tooltip label callbacks within UniversalChart.jsx.

## Status:
Opening this as a Draft PR for early architectural review. I am currently unable to test the UI rendering locally because the dashboard is blocked by the ["cell info"] data is undefined error currently present on main. Once that upstream issue is resolved, I will test the tooltips locally and mark this ready for review.