### PR TITLE
fix(docker): set explicit home dir for app user to resolve permission issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ When adding a new entry, please use the following format:
 
 ## Log
 
+- [2026-04-01] fix: set explicit home directory for app user to resolve Gunicorn and worker permission issues [#742](https://github.com/jlab-sensing/ENTS-backend/pull/742)
 - [2026-03-30] fix: added test decorators to resolve lack of "TTN_API_KEY" on fork PR's. removed k6 from github actions. changed github action to utilize env-import.py as opposeed to directly accessing s3 bucket for env variables. [#736] (https://github.com/jlab-sensing/ENTS-backend/pull/736)
 - [2026-03-23] fix: increase fallback SECRET_KEY length to resolve PyJWT InsecureKeyLengthWarning [#682](https://github.com/jlab-sensing/ENTS-backend/pull/682)
 - [2026-03-12] fix: safely catch PyJWT DecodeErrors and remove log spam for invalid tokens [#683](https://github.com/jlab-sensing/ENTS-backend/pull/683)

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -38,9 +38,11 @@ RUN pip install --no-cache-dir -r /tmp/requirements.txt
 #RUN pip wheel --no-cache-dir --no-deps --wheel-dir /usr/src/app/wheels -r requirements.txt
 
 # create new user and group to run the app with name "app"
-RUN adduser --system --group app
+# Give the user an explicit home directory OUTSIDE the mounted volume
+RUN adduser --system --group --home /home/app app
+ENV HOME=/home/app
 USER app
-WORKDIR $HOME
+WORKDIR /app
 
 # copy files from source tree
 COPY . .


### PR DESCRIPTION
**Name:** Abhinav Mishra  
**Affiliation/Title:** GSV, Contributor  

**Purpose of the PR** Resolves an `[Errno 13] Permission denied` error during local backend and worker startup by correctly configuring the Docker `app` user's home directory.

**Summary** When running `docker compose up --build` locally, the environment was failing to start. Gunicorn was throwing a permission denied error when trying to create its control socket (`gunicorn.ctl`), which subsequently caused the Celery worker container to fail as well, since they share the same base image.

This PR modifies `backend/Dockerfile` to explicitly assign a home directory (`/home/app`) to the `app` user that sits entirely outside the mounted volume, and sets the `HOME` environment variable accordingly. This ensures the user has the correct write permissions without interfering with the local volume mount, allowing both the main backend server and the background worker to boot cleanly.

**Development Environment** * **OS:** Linux (Ubuntu)  
* **Python/Docker version:** Python 3.11 / Docker Compose  

**Task List** - [x] All environments can be built  
- [x] All tests pass  
- [x] Linting passes  
- [x] Updated the `CHANGELOG.md`  
- [ ] Static code analysis passes  
- [ ] Clear documentation for new code (N/A)  

**Relevant Issues** Closes #670  
Replaces #678