### PR TITLE
Profile Redirect to Nav Bar

### DIFF
--- a/backend/tests/test_apikey_auth.py
+++ b/backend/tests/test_apikey_auth.py
@@ -61,40 +61,32 @@ def test_apikey_endpoint_accepts_jwt(init_database):
     assert response.status_code != 404
 
 
-def test_protected_cell_endpoint_accepts_apikey(init_database):
+def test_protected_tag_endpoint_accepts_apikey(init_database):
     user = make_user(
-        email="apikey-only-user@edx.com",
-        api_key="valid-apikey-for-cell_test",
+        email="apikey-only-user@tag.com",
+        api_key="valid-apikey-for-tag_test",
     )
 
     response = init_database.post(
-        "/api/cell/",
+        "/api/tag/",
         json={
-            "name": "API Key Test Cell",
-            "location": "Test Location",
-            "latitude": 0,
-            "longitude": 0,
-            "userEmail": user.email,
-            "archive": False,
+            "name": "API Key Test Tag",
+            "description": "Created with API key auth",
         },
         headers={"X-API-Key": user.api_key},
         content_type="application/json",
     )
-    assert response.status_code == 200
+    assert response.status_code == 201
     data = response.get_json()
-    assert data["message"] == "Successfully added cell"
+    assert data["message"] == "Tag created successfully"
 
 
-def test_protected_cell_endpoint_rejects_invalid_apikey(init_database):
+def test_protected_tag_endpoint_rejects_invalid_apikey(init_database):
     response = init_database.post(
-        "/api/cell/",
+        "/api/tag/",
         json={
-            "name": "Bad API Key Cell",
-            "location": "Test Location",
-            "latitude": 0,
-            "longitude": 0,
-            "userEmail": "missing@x.com",
-            "archive": False,
+            "name": "Bad API Key Tag",
+            "description": "Should not be created",
         },
         headers={"X-API-Key": "not-real-key"},
         content_type="application/json",

--- a/frontend/src/components/Nav.jsx
+++ b/frontend/src/components/Nav.jsx
@@ -66,6 +66,7 @@ function Nav({ user, setUser, loggedIn, setLoggedIn }) {
     dashboard: location.pathname.startsWith('/dashboard'),
     map: location.pathname.startsWith('/map'),
     docs: location.pathname.startsWith('/docs'),
+    profile: location.pathname.startsWith('/profile'),
   }), [location.pathname]);
 
   return (
@@ -101,6 +102,9 @@ function Nav({ user, setUser, loggedIn, setLoggedIn }) {
               </ListItemButton>
               <ListItemButton onClick={() => { navigate('/docs'); closeDrawer(); }}>
                 <ListItemText primary='Docs' />
+              </ListItemButton>
+              <ListItemButton onClick={() => { navigate('/profile'); closeDrawer(); }}>
+                <ListItemText primary='Profile' />
               </ListItemButton>
             </List>
             <Divider />
@@ -160,6 +164,12 @@ function Nav({ user, setUser, loggedIn, setLoggedIn }) {
               backgroundColor: isActive.docs ? '#0F172A' : 'transparent',
               '&:hover': { backgroundColor: isActive.docs ? '#111827' : 'rgba(0,0,0,0.04)' }
             }}>Docs</Button>
+            <Button onClick={() => navigate('/profile')} sx={{
+              textTransform: 'none', borderRadius: '999px', px: 1.75, py: 0.5, fontWeight: 700,
+              color: isActive.profile ? '#FFFFFF' : '#0F172A',
+              backgroundColor: isActive.profile ? '#0F172A' : 'transparent',
+              '&:hover': { backgroundColor: isActive.profile ? '#111827' : 'rgba(0,0,0,0.04)' }
+            }}>Profile</Button>
           </Box>
         </Box>
 
@@ -175,7 +185,6 @@ function Nav({ user, setUser, loggedIn, setLoggedIn }) {
                 Hi, {user?.first_name}
               </Button>
               <Menu id='user-menu' anchorEl={anchorElProfileMenu} anchorOrigin={{ vertical: 'bottom', horizontal: 'left' }} keepMounted transformOrigin={{ vertical: 'top', horizontal: 'left' }} open={Boolean(anchorElProfileMenu)} onClose={handleCloseProfileMenu}>
-                <MenuItem onClick={() => navigate('/profile')}>Profile</MenuItem>
                 <MenuItem onClick={() => logout()}>Logout</MenuItem>
               </Menu>
             </>


### PR DESCRIPTION
Moved the profile button from the "Hi, {USER}" menu to the top Nav Bar.

This is an important fix because depending on the size of the the users screen/ if the user is on mobile, there are times when accessing the profile is impossible without typing '/profile' into the url bar. No functionality changes, only moving the profile button from the leftmost menu to the middle.

If a user is not signed in it redirects them to the home page. If it is preferable, I can make it so that if not signed in, clicking profile redirects to the sign in page. 

Fixed the failing backend test. They tested against posting a cell with and without a valid api key. Posting a cell is no longer auth guarded so the tests failed.  Switched those tests to be testing against posting a tag, which is auth guarded.