### PR TITLE
Fix sensor catalog to discover panels from DB sensor rows.

### DIFF
--- a/backend/api/resources/sensor_catalog.py
+++ b/backend/api/resources/sensor_catalog.py
@@ -1,97 +1,19 @@
-"""Read-only sensor catalog for dashboard chart picker."""
+"""Read-only sensor catalog for dashboard chart picker.
+
+Builtin power/TEROS panels still come from legacy tables. Generic chartable
+panels are discovered from the ``sensor`` table (name / measurement / unit
+written at ingest via ``ents`` ``parse_sensor_measurement``).
+"""
 
 from flask import request
 from flask_restful import Resource
+from sqlalchemy import exists
 
+from ..models.data import Data
 from ..models.power_data import PowerData
 from ..models.sensor import Sensor
 from ..models.teros_data import TEROSData
 
-
-# Matches frontend UNIFIED_CATALOG + UnifiedChart CHART_CONFIGS
-_UNIFIED_SPECS = [
-    {
-        "panel_id": "u:co2",
-        "unified_type": "co2",
-        "label": "CO₂",
-        "description": "sensor · co2 · ppm",
-        "category": "generic",
-        "sensor_name": "co2",
-        "measurements": ["co2"],
-    },
-    {
-        "panel_id": "u:presHum",
-        "unified_type": "presHum",
-        "label": "Pressure & humidity",
-        "description": "bme280 · pressure & humidity",
-        "category": "generic",
-        "sensor_name": "bme280",
-        "measurements": ["pressure", "humidity"],
-    },
-    {
-        "panel_id": "u:bme280Pressure",
-        "unified_type": "bme280Pressure",
-        "label": "BME280 pressure",
-        "description": "bme280 · pressure",
-        "category": "generic",
-        "sensor_name": "bme280",
-        "measurements": ["Pressure", "pressure"],
-    },
-    {
-        "panel_id": "u:soilPot",
-        "unified_type": "soilPot",
-        "label": "Soil water potential",
-        "description": "teros21 · matric potential",
-        "category": "generic",
-        "sensor_name": "teros21",
-        "measurements": ["soil_water_potential"],
-    },
-    {
-        "panel_id": "u:soilHum",
-        "unified_type": "soilHum",
-        "label": "Soil humidity",
-        "description": "sen0308 · humidity",
-        "category": "generic",
-        "sensor_name": "sen0308",
-        "measurements": ["humidity"],
-    },
-    {
-        "panel_id": "u:waterPress",
-        "unified_type": "waterPress",
-        "label": "Water pressure",
-        "description": "sen0257 · pressure",
-        "category": "generic",
-        "sensor_name": "sen0257",
-        "measurements": ["pressure"],
-    },
-    {
-        "panel_id": "u:waterFlow",
-        "unified_type": "waterFlow",
-        "label": "Water flow",
-        "description": "yfs210c · flow",
-        "category": "generic",
-        "sensor_name": "yfs210c",
-        "measurements": ["flow"],
-    },
-    {
-        "panel_id": "u:sensor",
-        "unified_type": "sensor",
-        "label": "Dielectric permittivity",
-        "description": "phytos31 · permittivity",
-        "category": "generic",
-        "sensor_name": "phytos31",
-        "measurements": ["dielectric_permittivity"],
-    },
-    {
-        "panel_id": "u:temperature",
-        "unified_type": "temperature",
-        "label": "Temperature (BME280)",
-        "description": "bme280 · temperature",
-        "category": "generic",
-        "sensor_name": "bme280",
-        "measurements": ["temperature", "Temperature"],
-    },
-]
 
 _BUILTIN_SPECS = [
     {
@@ -133,16 +55,37 @@ def _has_teros_data(cell_id: int) -> bool:
     return TEROSData.query.filter_by(cell_id=cell_id).first() is not None
 
 
-def _unified_available(cell_id: int, spec: dict) -> bool:
-    for measurement in spec["measurements"]:
-        row = Sensor.query.filter_by(
-            cell_id=cell_id,
-            name=spec["sensor_name"],
-            measurement=measurement,
-        ).first()
-        if row is not None:
-            return True
-    return False
+def _sensors_with_data(cell_id: int) -> list[Sensor]:
+    """Return sensors for a cell that have at least one data row."""
+    has_data = exists().where(Data.sensor_id == Sensor.id)
+    return (
+        Sensor.query.filter(Sensor.cell_id == cell_id, has_data)
+        .order_by(Sensor.name.asc(), Sensor.measurement.asc(), Sensor.id.asc())
+        .all()
+    )
+
+
+def _entry_from_sensor(sensor: Sensor) -> dict:
+    unit = sensor.unit or ""
+    measurement = sensor.measurement or ""
+    name = sensor.name or ""
+    label = measurement or name or f"Sensor {sensor.id}"
+    description_parts = [part for part in (name, measurement, unit) if part]
+    return {
+        "panel_id": f"s:{sensor.id}",
+        "label": label,
+        "description": " · ".join(description_parts) if description_parts else label,
+        "category": "generic",
+        "kind": "sensor",
+        "sensor_id": sensor.id,
+        "sensor_name": name,
+        "measurement": measurement,
+        "unit": unit,
+    }
+
+
+def _sensor_entries(cell_id: int) -> list[dict]:
+    return [_entry_from_sensor(sensor) for sensor in _sensors_with_data(cell_id)]
 
 
 class SensorCatalog(Resource):
@@ -165,17 +108,6 @@ class SensorCatalog(Resource):
                 [e for e in _BUILTIN_SPECS if e["panel_id"] in ("teros", "temp")]
             )
 
-        for spec in _UNIFIED_SPECS:
-            if _unified_available(cell_id, spec):
-                entries.append(
-                    {
-                        "panel_id": spec["panel_id"],
-                        "label": spec["label"],
-                        "description": spec["description"],
-                        "category": spec["category"],
-                        "kind": "unified",
-                        "unified_type": spec["unified_type"],
-                    }
-                )
+        entries.extend(_sensor_entries(cell_id))
 
         return {"cell_id": cell_id, "entries": entries}

--- a/backend/tests/test_sensor_catalog.py
+++ b/backend/tests/test_sensor_catalog.py
@@ -1,6 +1,7 @@
 from datetime import datetime
 
 from api.models.cell import Cell
+from api.models.data import Data
 from api.models.power_data import PowerData
 from api.models.sensor import Sensor
 from api.models.teros_data import TEROSData
@@ -12,7 +13,7 @@ def test_sensor_catalog_requires_cell_id(test_client, init_database):
     assert response.get_json()["error"] == "cell_id parameter is required"
 
 
-def test_sensor_catalog_returns_builtin_and_unified_entries(test_client, init_database):
+def test_sensor_catalog_returns_builtins_and_db_sensors(test_client, init_database):
     cell = Cell("catalog_cell", "", 1, 1, False, None)
     cell.save()
 
@@ -27,6 +28,17 @@ def test_sensor_catalog_returns_builtin_and_unified_entries(test_client, init_da
         unit="ppm",
     )
     co2_sensor.save()
+    Data(sensor_id=co2_sensor.id, ts=datetime.now(), float_val=410.0).save()
+
+    unknown = Sensor(
+        name="rocketlogger",
+        measurement="soil_moisture",
+        data_type="float",
+        cell_id=cell.id,
+        unit="%",
+    )
+    unknown.save()
+    Data(sensor_id=unknown.id, ts=datetime.now(), float_val=22.5).save()
 
     response = test_client.get(f"/api/catalog/sensors?cell_id={cell.id}")
     assert response.status_code == 200
@@ -39,7 +51,35 @@ def test_sensor_catalog_returns_builtin_and_unified_entries(test_client, init_da
     assert "power-p" in panel_ids
     assert "teros" in panel_ids
     assert "temp" in panel_ids
-    assert "u:co2" in panel_ids
+    assert f"s:{co2_sensor.id}" in panel_ids
+    assert f"s:{unknown.id}" in panel_ids
+
+    unknown_entry = next(
+        entry for entry in payload["entries"] if entry["panel_id"] == f"s:{unknown.id}"
+    )
+    assert unknown_entry["kind"] == "sensor"
+    assert unknown_entry["sensor_name"] == "rocketlogger"
+    assert unknown_entry["measurement"] == "soil_moisture"
+    assert unknown_entry["unit"] == "%"
+    assert unknown_entry["label"] == "soil_moisture"
+
+
+def test_sensor_catalog_skips_sensors_without_data(test_client, init_database):
+    cell = Cell("catalog_empty_data", "", 1, 1, False, None)
+    cell.save()
+
+    orphan = Sensor(
+        name="orphan",
+        measurement="value",
+        data_type="float",
+        cell_id=cell.id,
+        unit="1",
+    )
+    orphan.save()
+
+    response = test_client.get(f"/api/catalog/sensors?cell_id={cell.id}")
+    assert response.status_code == 200
+    assert response.get_json()["entries"] == []
 
 
 def test_sensor_catalog_empty_when_cell_has_no_data(test_client, init_database):

--- a/frontend/src/pages/dashboard/Dashboard.jsx
+++ b/frontend/src/pages/dashboard/Dashboard.jsx
@@ -23,6 +23,7 @@ import {
   DEFAULT_DASHBOARD_PANEL_ORDER,
   isKnownPanelId,
   isDerivedPanelEntry,
+  isSensorPanelEntry,
   parseLayoutParam,
   serializeLayoutParam,
 } from './catalog/dashboardCatalog';
@@ -191,7 +192,9 @@ function Dashboard() {
     () => ({
       power: !stream && panelOrderNeedsPower(panelOrderForFetch),
       teros: !stream && panelOrderNeedsTeros(panelOrderForFetch),
-      sensors: !stream && panelOrderForFetch.some((panelId) => panelId.startsWith('u:')),
+      sensors:
+        !stream &&
+        panelOrderForFetch.some((panelId) => panelId.startsWith('u:') || isSensorPanelEntry(panelId)),
       equations: !stream && panelOrderForFetch.some((panelId) => isDerivedPanelEntry(panelId)),
     }),
     [stream, panelOrderForFetch],

--- a/frontend/src/pages/dashboard/catalog/cellSensorLayout.js
+++ b/frontend/src/pages/dashboard/catalog/cellSensorLayout.js
@@ -3,7 +3,12 @@ import { getSensorCatalog } from '../../../services/catalog';
 import { getCellSensors } from '../../../services/cell';
 import { measurementMatches } from '../components/unifiedChartUtils';
 import { isDerivedLayoutEntry } from '../equation/equationParser';
-import { BUILTIN_CATALOG, UNIFIED_CATALOG, isKnownPanelId } from './dashboardCatalog';
+import {
+  BUILTIN_CATALOG,
+  UNIFIED_CATALOG,
+  isKnownPanelId,
+  isSensorPanelEntry,
+} from './dashboardCatalog';
 
 /** Map UnifiedChart config keys to dashboard panel IDs. */
 const CHART_TYPE_TO_PANEL_ID = {
@@ -47,6 +52,12 @@ export function panelIdsFromCellSensors(cellSensorsById, selectedCellIds) {
   Object.entries(cellSensorsById).forEach(([cellId, sensors]) => {
     if (!selectedSet.has(cellId) || !Array.isArray(sensors)) return;
 
+    sensors.forEach((sensor) => {
+      if (sensor?.id != null) {
+        panelIds.add(`s:${sensor.id}`);
+      }
+    });
+
     Object.entries(CHART_CONFIGS).forEach(([chartType, config]) => {
       const matches = sensors.some(
         (sensor) =>
@@ -86,6 +97,11 @@ export function sortPanelIds(panelSet) {
       ordered.push(entry.panelId);
     }
   });
+
+  [...panelSet]
+    .filter((panelId) => isSensorPanelEntry(panelId) && !ordered.includes(panelId))
+    .sort((a, b) => a.localeCompare(b, undefined, { numeric: true }))
+    .forEach((panelId) => ordered.push(panelId));
 
   return ordered;
 }
@@ -130,10 +146,6 @@ export async function fetchCatalogPanelIdsForCells(cellIds) {
   return sortPanelIds(seen);
 }
 
-/**
- * @param {Array<string|number>} cellIds
- * @returns {Promise<{ panelOrder: string[], cellSensorsById: Record<string, unknown[]> }>}
- */
 /**
  * @param {Record<string, unknown[]>} cellSensorsById
  * @param {Array<string|number>} cellIds

--- a/frontend/src/pages/dashboard/catalog/cellSensorLayout.test.js
+++ b/frontend/src/pages/dashboard/catalog/cellSensorLayout.test.js
@@ -36,6 +36,13 @@ describe('sortPanelIds', () => {
     expect(ordered).toContain('power-p');
     expect(ordered.indexOf('power-vi')).toBeLessThan(ordered.indexOf('u:co2'));
   });
+
+  it('appends s: panels after builtins and unified, sorted numerically', () => {
+    const ordered = sortPanelIds(new Set(['s:12', 'u:co2', 's:2', 'power-vi']));
+    expect(ordered[0]).toBe('power-vi');
+    expect(ordered.indexOf('u:co2')).toBeLessThan(ordered.indexOf('s:2'));
+    expect(ordered.indexOf('s:2')).toBeLessThan(ordered.indexOf('s:12'));
+  });
 });
 
 describe('panelsMissingForCells', () => {

--- a/frontend/src/pages/dashboard/catalog/cellSensorLayout.test.js
+++ b/frontend/src/pages/dashboard/catalog/cellSensorLayout.test.js
@@ -19,12 +19,13 @@ import { getCellSensors } from '../../../services/cell';
 import { getSensorCatalog } from '../../../services/catalog';
 
 describe('panelIdsFromCellSensors', () => {
-  it('maps bme280 sensor rows to unified panel ids', () => {
+  it('maps bme280 sensor rows to unified panel ids and s:{id} panels', () => {
     const cellSensorsById = {
-      '1': [{ name: 'co2', measurement: 'co2' }],
+      '1': [{ id: 12, name: 'co2', measurement: 'co2' }],
     };
     const ids = panelIdsFromCellSensors(cellSensorsById, [1]);
     expect(ids.has('u:co2')).toBe(true);
+    expect(ids.has('s:12')).toBe(true);
   });
 });
 
@@ -59,10 +60,17 @@ describe('buildDefaultPanelOrder', () => {
   });
 
   it('merges catalog and sensor-derived panels with power-vi first', async () => {
-    getCellSensors.mockResolvedValue([{ name: 'co2', measurement: 'co2' }]);
+    getCellSensors.mockResolvedValue([{ id: 5, name: 'co2', measurement: 'co2' }]);
     getSensorCatalog.mockResolvedValue([
       { panel_id: 'power-vi', label: 'Voltage & Current' },
       { panel_id: 'teros', label: 'VWC & EC' },
+      {
+        panel_id: 's:5',
+        kind: 'sensor',
+        sensor_id: 5,
+        sensor_name: 'co2',
+        measurement: 'co2',
+      },
     ]);
 
     const { panelOrder, cellSensorsById } = await buildDefaultPanelOrder([1]);
@@ -70,6 +78,7 @@ describe('buildDefaultPanelOrder', () => {
     expect(panelOrder[0]).toBe('power-vi');
     expect(panelOrder).toContain('teros');
     expect(panelOrder).toContain('u:co2');
+    expect(panelOrder).toContain('s:5');
     expect(cellSensorsById['1']).toHaveLength(1);
   });
 });

--- a/frontend/src/pages/dashboard/catalog/dashboardCatalog.js
+++ b/frontend/src/pages/dashboard/catalog/dashboardCatalog.js
@@ -1,4 +1,4 @@
-/** @typedef {'builtin' | 'unified'} PanelKind */
+/** @typedef {'builtin' | 'unified' | 'sensor'} PanelKind */
 
 /**
  * @typedef {object} CatalogEntry
@@ -8,6 +8,10 @@
  * @property {string} category
  * @property {PanelKind} kind
  * @property {string} [unifiedType] - UnifiedChart `type` when kind === 'unified'
+ * @property {number} [sensorId]
+ * @property {string} [sensorName]
+ * @property {string} [measurement]
+ * @property {string} [unit]
  */
 
 export const LAYOUT_VERSION = 'v1';
@@ -46,7 +50,7 @@ export const BUILTIN_CATALOG = [
   },
 ];
 
-/** Catalog entries backed by UnifiedChart types. */
+/** Catalog entries backed by UnifiedChart types (legacy URL tokens). */
 export const UNIFIED_CATALOG = [
   { panelId: 'u:co2', unifiedType: 'co2', label: 'CO₂', description: 'sensor · co2 · ppm', category: 'generic' },
   {
@@ -111,6 +115,8 @@ const ALL_ENTRIES = [...BUILTIN_CATALOG, ...UNIFIED_CATALOG];
 
 const PANEL_ID_SET = new Set(ALL_ENTRIES.map((e) => e.panelId));
 
+const SENSOR_PANEL_ID_RE = /^s:\d+$/;
+
 /** Unified types rendered in the legacy bottom stack (auto, not in panel grid). */
 export const LEGACY_BOTTOM_UNIFIED_TYPES = [
   'power_voltage',
@@ -132,6 +138,23 @@ export const LEGACY_BOTTOM_UNIFIED_TYPES = [
 
 /**
  * @param {string} panelId
+ * @returns {boolean}
+ */
+export function isSensorPanelEntry(panelId) {
+  return typeof panelId === 'string' && SENSOR_PANEL_ID_RE.test(panelId);
+}
+
+/**
+ * @param {string} panelId
+ * @returns {number | null}
+ */
+export function sensorPanelIdToSensorId(panelId) {
+  if (!isSensorPanelEntry(panelId)) return null;
+  return Number(panelId.slice(2));
+}
+
+/**
+ * @param {string} panelId
  * @returns {CatalogEntry | undefined}
  */
 export function getCatalogEntry(panelId) {
@@ -142,7 +165,7 @@ export function getCatalogEntry(panelId) {
  * @param {string} panelId
  */
 export function isKnownPanelId(panelId) {
-  return PANEL_ID_SET.has(panelId);
+  return PANEL_ID_SET.has(panelId) || isSensorPanelEntry(panelId);
 }
 
 /**
@@ -180,6 +203,20 @@ export function catalogEntriesFromApi(apiEntries) {
   const byId = new Map(ALL_ENTRIES.map((e) => [e.panelId, e]));
   return apiEntries
     .map((row) => {
+      if (row.kind === 'sensor' || isSensorPanelEntry(row.panel_id)) {
+        return {
+          panelId: row.panel_id,
+          label: row.label || row.measurement || row.sensor_name || row.panel_id,
+          description: row.description || '',
+          category: row.category || 'generic',
+          kind: 'sensor',
+          sensorId: row.sensor_id,
+          sensorName: row.sensor_name,
+          measurement: row.measurement,
+          unit: row.unit || '',
+        };
+      }
+
       const base = byId.get(row.panel_id);
       if (!base) return null;
       return {

--- a/frontend/src/pages/dashboard/catalog/dashboardCatalog.test.js
+++ b/frontend/src/pages/dashboard/catalog/dashboardCatalog.test.js
@@ -40,10 +40,17 @@ describe('dashboardCatalog layout helpers', () => {
 });
 
 describe('dashboardCatalog panel id helpers', () => {
-  it('recognizes known builtin and unified panel ids', () => {
+  it('recognizes known builtin, unified, and db sensor panel ids', () => {
     expect(isKnownPanelId('power-vi')).toBe(true);
     expect(isKnownPanelId('u:co2')).toBe(true);
+    expect(isKnownPanelId('s:42')).toBe(true);
+    expect(isKnownPanelId('s:abc')).toBe(false);
     expect(isKnownPanelId('missing')).toBe(false);
+  });
+
+  it('parses and serializes db sensor panel ids in layout', () => {
+    expect(parseLayoutParam('v1:vi,s:37,temp')).toEqual(['power-vi', 's:37', 'temp']);
+    expect(serializeLayoutParam(['power-vi', 's:37'])).toBe('v1:vi,s:37');
   });
 
   it('maps unified types to panel ids and back', () => {
@@ -82,5 +89,29 @@ describe('catalogEntriesFromApi', () => {
 
   it('falls back to full catalog for non-array input', () => {
     expect(catalogEntriesFromApi(null).length).toBeGreaterThan(4);
+  });
+
+  it('maps db sensor rows from the catalog API', () => {
+    const entries = catalogEntriesFromApi([
+      {
+        panel_id: 's:99',
+        label: 'soil_moisture',
+        description: 'rocketlogger · soil_moisture · %',
+        category: 'generic',
+        kind: 'sensor',
+        sensor_id: 99,
+        sensor_name: 'rocketlogger',
+        measurement: 'soil_moisture',
+        unit: '%',
+      },
+    ]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      panelId: 's:99',
+      kind: 'sensor',
+      sensorName: 'rocketlogger',
+      measurement: 'soil_moisture',
+      unit: '%',
+    });
   });
 });

--- a/frontend/src/pages/dashboard/catalog/dashboardCatalog.test.js
+++ b/frontend/src/pages/dashboard/catalog/dashboardCatalog.test.js
@@ -4,8 +4,10 @@ import {
   getCatalogEntry,
   getUnifiedTypesInPanelOrder,
   isKnownPanelId,
+  isSensorPanelEntry,
   panelIdToUnifiedType,
   parseLayoutParam,
+  sensorPanelIdToSensorId,
   serializeLayoutParam,
   unifiedTypeToPanelId,
 } from './dashboardCatalog';
@@ -113,5 +115,30 @@ describe('catalogEntriesFromApi', () => {
       measurement: 'soil_moisture',
       unit: '%',
     });
+  });
+
+  it('treats s: panel_id as sensor even without kind and falls back for labels', () => {
+    const [entry] = catalogEntriesFromApi([
+      {
+        panel_id: 's:7',
+        sensor_id: 7,
+        sensor_name: 'bootstrap',
+        measurement: 'raw',
+      },
+    ]);
+    expect(entry).toMatchObject({
+      panelId: 's:7',
+      kind: 'sensor',
+      label: 'raw',
+      unit: '',
+      sensorName: 'bootstrap',
+    });
+  });
+
+  it('parses sensor panel ids', () => {
+    expect(isSensorPanelEntry('s:42')).toBe(true);
+    expect(isSensorPanelEntry(42)).toBe(false);
+    expect(sensorPanelIdToSensorId('s:42')).toBe(42);
+    expect(sensorPanelIdToSensorId('u:co2')).toBeNull();
   });
 });

--- a/frontend/src/pages/dashboard/catalog/historicalDataLoader.js
+++ b/frontend/src/pages/dashboard/catalog/historicalDataLoader.js
@@ -1,16 +1,28 @@
-import { getPowerData } from '../../../services/power';
-import { getTerosData } from '../../../services/teros';
-import { getSensorData } from '../../../services/sensor';
-import { CHART_CONFIGS } from '../components/chartConfigs';
-import { panelIdToUnifiedType } from './dashboardCatalog';
+import { panelIdToUnifiedType, isSensorPanelEntry, sensorPanelIdToSensorId } from './dashboardCatalog';
 import { measurementMatches } from '../components/unifiedChartUtils';
 import { extractCellStreamRefs, isDerivedLayoutEntry } from '../equation/equationParser';
 import { resolveStreamSpec } from '../equation/equationStreams';
+import { CHART_CONFIGS } from '../components/chartConfigs';
+import { getPowerData } from '../../../services/power';
+import { getTerosData } from '../../../services/teros';
+import { getSensorData } from '../../../services/sensor';
 
 export { measurementMatches };
 
 export function sensorDataCacheKey(cellId, sensorName, measurement) {
   return `${cellId}:${sensorName}:${measurement}`.toLowerCase();
+}
+
+/**
+ * @param {string} panelId
+ * @param {Record<string, unknown[]>} cellSensorsById
+ */
+export function findSensorByPanelId(cellSensorsById, panelId) {
+  const sensorId = sensorPanelIdToSensorId(panelId);
+  if (sensorId == null) return null;
+  return Object.values(cellSensorsById || {})
+    .flatMap((sensors) => (Array.isArray(sensors) ? sensors : []))
+    .find((sensor) => Number(sensor?.id) === sensorId);
 }
 
 /**
@@ -174,13 +186,58 @@ export function collectUnifiedSensorRequests(panelOrder, cells, cellSensorsById)
 }
 
 /**
+ * @param {string[]} panelOrder
+ * @param {Array<{ id: string|number }>} cells
+ * @param {Record<string, unknown[]>} cellSensorsById
+ */
+export function collectDbSensorPanelRequests(panelOrder, cells, cellSensorsById) {
+  const requests = [];
+  const seen = new Set();
+
+  panelOrder.forEach((panelId) => {
+    if (!isSensorPanelEntry(panelId)) return;
+    const sensor = findSensorByPanelId(cellSensorsById, panelId);
+    if (!sensor?.name || !sensor?.measurement) return;
+
+    cells.forEach((cell) => {
+      const cellSensors = cellSensorsById[String(cell.id)] || [];
+      if (!cellSensors.some((row) => Number(row?.id) === Number(sensor.id))) return;
+
+      const cacheKey = sensorDataCacheKey(cell.id, sensor.name, sensor.measurement);
+      if (seen.has(cacheKey)) return;
+      seen.add(cacheKey);
+      requests.push({
+        cacheKey,
+        cellId: cell.id,
+        name: sensor.name,
+        measurement: sensor.measurement,
+      });
+    });
+  });
+
+  return requests;
+}
+
+/**
  * @param {Array<{ id: string|number, name: string }>} cells
  * @param {string} unifiedType
  * @param {Record<string, unknown[]>} cellSensorsById
  * @param {Record<string, unknown>} historicalSensorByKey
+ * @param {{ sensor_name: string, measurements: string[] } | null} [sensorSpec]
  */
-export function buildUnifiedChartDataFromCache(cells, unifiedType, cellSensorsById, historicalSensorByKey) {
-  const config = CHART_CONFIGS[unifiedType];
+export function buildUnifiedChartDataFromCache(
+  cells,
+  unifiedType,
+  cellSensorsById,
+  historicalSensorByKey,
+  sensorSpec = null,
+) {
+  const config = sensorSpec
+    ? {
+        sensor_name: sensorSpec.sensor_name,
+        measurements: sensorSpec.measurements,
+      }
+    : CHART_CONFIGS[unifiedType];
   if (!config) return {};
 
   const entries = cells.map(({ id, name }) => {
@@ -260,6 +317,7 @@ export async function fetchDashboardHistoricalData({
 
   const sensorRequests = [
     ...collectUnifiedSensorRequests(panelOrder, cells, cellSensorsById),
+    ...collectDbSensorPanelRequests(panelOrder, cells, cellSensorsById),
     ...collectEquationSensorRequests(panelOrder),
   ];
   const seen = new Set();
@@ -372,6 +430,7 @@ export async function fetchDashboardSensorData({
   const endHTTP = endDate.toHTTP();
   const sensorRequests = [
     ...collectUnifiedSensorRequests(panelOrder, cells, cellSensorsById),
+    ...collectDbSensorPanelRequests(panelOrder, cells, cellSensorsById),
     ...collectEquationSensorRequests(panelOrder),
   ];
   const seen = new Set();

--- a/frontend/src/pages/dashboard/catalog/historicalDataLoader.test.js
+++ b/frontend/src/pages/dashboard/catalog/historicalDataLoader.test.js
@@ -1,14 +1,29 @@
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { DateTime } from 'luxon';
 import {
+  buildUnifiedChartDataFromCache,
+  collectDbSensorPanelRequests,
   collectEquationRefsFromPanelOrder,
   collectEquationSensorRequests,
   collectUnifiedSensorRequests,
+  fetchDashboardSensorData,
+  findSensorByPanelId,
   panelOrderNeedsPower,
   panelOrderNeedsTeros,
   sensorDataCacheKey,
 } from './historicalDataLoader';
 
+vi.mock('../../../services/sensor', () => ({
+  getSensorData: vi.fn(),
+}));
+
+import { getSensorData } from '../../../services/sensor';
+
 describe('historicalDataLoader', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
   it('detects power and teros panel needs', () => {
     expect(panelOrderNeedsPower(['power-vi', 'teros'])).toBe(true);
     expect(panelOrderNeedsPower(['teros', 'temp'])).toBe(false);
@@ -54,5 +69,103 @@ describe('historicalDataLoader', () => {
     const requests = collectEquationSensorRequests(['1:co2 * 2']);
     expect(requests).toHaveLength(1);
     expect(requests[0].cacheKey).toBe(sensorDataCacheKey(1, 'co2', 'co2'));
+  });
+
+  it('finds sensors by s:{id} panel id', () => {
+    const cellSensorsById = {
+      1: [{ id: 37, name: 'rocketlogger', measurement: 'soil_moisture' }],
+      2: [{ id: 12, name: 'co2', measurement: 'co2' }],
+    };
+    expect(findSensorByPanelId(cellSensorsById, 's:37')).toMatchObject({
+      id: 37,
+      name: 'rocketlogger',
+    });
+    expect(findSensorByPanelId(cellSensorsById, 's:999')).toBeUndefined();
+    expect(findSensorByPanelId(cellSensorsById, 'u:co2')).toBeNull();
+    expect(findSensorByPanelId(null, 's:37')).toBeUndefined();
+  });
+
+  it('collects db sensor panel requests only for matching cells', () => {
+    const cellSensorsById = {
+      1: [{ id: 37, name: 'rocketlogger', measurement: 'soil_moisture' }],
+      2: [{ id: 12, name: 'co2', measurement: 'co2' }],
+    };
+
+    const requests = collectDbSensorPanelRequests(
+      ['s:37', 's:12', 'u:co2', 's:999'],
+      [{ id: 1 }, { id: 2 }],
+      cellSensorsById,
+    );
+
+    expect(requests).toEqual([
+      {
+        cacheKey: sensorDataCacheKey(1, 'rocketlogger', 'soil_moisture'),
+        cellId: 1,
+        name: 'rocketlogger',
+        measurement: 'soil_moisture',
+      },
+      {
+        cacheKey: sensorDataCacheKey(2, 'co2', 'co2'),
+        cellId: 2,
+        name: 'co2',
+        measurement: 'co2',
+      },
+    ]);
+  });
+
+  it('skips db sensor panels missing name or measurement', () => {
+    expect(
+      collectDbSensorPanelRequests(['s:1'], [{ id: 1 }], {
+        1: [{ id: 1, name: 'orphan' }],
+      }),
+    ).toEqual([]);
+  });
+
+  it('builds unified chart cache rows from a db sensorSpec', () => {
+    const cacheKey = sensorDataCacheKey(1, 'rocketlogger', 'soil_moisture');
+    const chartData = buildUnifiedChartDataFromCache(
+      [{ id: 1, name: 'Cell A' }],
+      null,
+      {
+        1: [{ id: 37, name: 'rocketlogger', measurement: 'soil_moisture' }],
+      },
+      {
+        [cacheKey]: { timestamp: ['Thu, 18 Jun 2026 00:00:00 GMT'], data: [12] },
+      },
+      { sensor_name: 'rocketlogger', measurements: ['soil_moisture'] },
+    );
+
+    expect(chartData[1]).toMatchObject({
+      name: 'Cell A',
+      soil_moisture: { timestamp: ['Thu, 18 Jun 2026 00:00:00 GMT'], data: [12] },
+    });
+  });
+
+  it('fetches historical sensor data for s: panels', async () => {
+    getSensorData.mockResolvedValue({ timestamp: [], data: [1] });
+    const start = DateTime.fromISO('2026-06-01T00:00:00');
+    const end = DateTime.fromISO('2026-06-02T00:00:00');
+
+    const result = await fetchDashboardSensorData({
+      cells: [{ id: 1, name: 'Cell A' }],
+      panelOrder: ['s:37'],
+      startDate: start,
+      endDate: end,
+      cellSensorsById: {
+        1: [{ id: 37, name: 'rocketlogger', measurement: 'soil_moisture' }],
+      },
+    });
+
+    expect(getSensorData).toHaveBeenCalledWith(
+      'rocketlogger',
+      1,
+      'soil_moisture',
+      start.toHTTP(),
+      end.toHTTP(),
+      'hour',
+    );
+    expect(result.historicalSensorByKey).toHaveProperty(
+      sensorDataCacheKey(1, 'rocketlogger', 'soil_moisture'),
+    );
   });
 });

--- a/frontend/src/pages/dashboard/catalog/layoutPanels.js
+++ b/frontend/src/pages/dashboard/catalog/layoutPanels.js
@@ -1,5 +1,6 @@
 import {
   isKnownPanelId,
+  isSensorPanelEntry,
   LAYOUT_VERSION,
   panelIdToUnifiedType,
 } from './dashboardCatalog';
@@ -60,7 +61,7 @@ export function splitLayoutEntries(body) {
  */
 export function resolveLayoutTokenToPanelId(token) {
   if (!token) return null;
-  if (isKnownPanelId(token)) return token;
+  if (isSensorPanelEntry(token) || isKnownPanelId(token)) return token;
 
   const alias = LAYOUT_NAME_TO_PANEL_ID[token] ?? LAYOUT_NAME_TO_PANEL_ID[token.toLowerCase()];
   if (alias && isKnownPanelId(alias)) return alias;

--- a/frontend/src/pages/dashboard/components/DashboardPanelGrid.jsx
+++ b/frontend/src/pages/dashboard/components/DashboardPanelGrid.jsx
@@ -9,12 +9,26 @@ import { SortableContext, arrayMove, rectSortingStrategy } from '@dnd-kit/sortab
 import { Box } from '@mui/material';
 import PropTypes from 'prop-types';
 import { useCallback, useMemo } from 'react';
-import { panelIdToUnifiedType, isDerivedPanelEntry } from '../catalog/dashboardCatalog';
+import {
+  panelIdToUnifiedType,
+  isDerivedPanelEntry,
+  isSensorPanelEntry,
+  sensorPanelIdToSensorId,
+} from '../catalog/dashboardCatalog';
+import ChartPanelPlaceholder from './ChartPanelPlaceholder';
 import DerivedEquationChart from './DerivedEquationChart';
 import PowerCharts from './PowerCharts';
 import SortableChartPanel from './SortableChartPanel';
 import TerosCharts from './TerosCharts';
 import UnifiedChart from './UnifiedChart';
+
+function findSensorByPanelId(cellSensorsById, panelId) {
+  const sensorId = sensorPanelIdToSensorId(panelId);
+  if (sensorId == null) return null;
+  return Object.values(cellSensorsById || {})
+    .flatMap((sensors) => (Array.isArray(sensors) ? sensors : []))
+    .find((sensor) => Number(sensor?.id) === sensorId);
+}
 
 function DashboardPanelContent({ panelId, chartProps }) {
   if (isDerivedPanelEntry(panelId)) {
@@ -40,6 +54,33 @@ function DashboardPanelContent({ panelId, chartProps }) {
     stream: chartProps.stream,
     liveData: chartProps.liveData,
   };
+
+  if (isSensorPanelEntry(panelId)) {
+    const sensor = findSensorByPanelId(chartProps.cellSensorsById, panelId);
+    if (!sensor?.name || !sensor?.measurement) {
+      return <ChartPanelPlaceholder />;
+    }
+    return (
+      <UnifiedChart
+        sensorSpec={{
+          sensor_name: sensor.name,
+          measurements: [sensor.measurement],
+          units: [sensor.unit || ''],
+          chartId: `db-sensor-${sensor.id}`,
+        }}
+        cells={chartProps.cells}
+        startDate={chartProps.startDate}
+        endDate={chartProps.endDate}
+        stream={chartProps.stream}
+        liveData={chartProps.liveData}
+        processedData={chartProps.processedSensors}
+        cellSensorsById={chartProps.cellSensorsById}
+        historicalSensorByKey={chartProps.historicalSensorByKey}
+        centralHistoricalActive={chartProps.centralHistoricalActive?.sensors}
+        historicalLoading={chartProps.historicalLoading}
+      />
+    );
+  }
 
   const unifiedType = panelIdToUnifiedType(panelId);
   if (unifiedType) {

--- a/frontend/src/pages/dashboard/components/DashboardPanelGrid.test.jsx
+++ b/frontend/src/pages/dashboard/components/DashboardPanelGrid.test.jsx
@@ -11,7 +11,13 @@ vi.mock('./TerosCharts', () => ({
 }));
 
 vi.mock('./UnifiedChart', () => ({
-  default: () => <div>Unified chart panel</div>,
+  default: ({ type, sensorSpec }) => (
+    <div>
+      {sensorSpec
+        ? `DB sensor chart: ${sensorSpec.sensor_name}/${sensorSpec.measurements.join(',')}`
+        : `Unified chart panel: ${type}`}
+    </div>
+  ),
 }));
 
 vi.mock('./DerivedEquationChart', () => ({
@@ -48,7 +54,49 @@ describe('DashboardPanelGrid', () => {
     );
 
     expect(screen.getByText('Power chart panel')).toBeInTheDocument();
-    expect(screen.getByText('Unified chart panel')).toBeInTheDocument();
+    expect(screen.getByText('Unified chart panel: co2')).toBeInTheDocument();
+  });
+
+  it('renders db sensor panels via UnifiedChart sensorSpec', () => {
+    render(
+      <DashboardPanelGrid
+        panelOrder={['s:37']}
+        onPanelOrderChange={vi.fn()}
+        onRemovePanel={vi.fn()}
+        panelColumns={2}
+        chartProps={{
+          ...chartProps,
+          cellSensorsById: {
+            1: [
+              {
+                id: 37,
+                name: 'rocketlogger',
+                measurement: 'soil_moisture',
+                unit: '%',
+              },
+            ],
+          },
+        }}
+      />,
+    );
+
+    expect(screen.getByText('DB sensor chart: rocketlogger/soil_moisture')).toBeInTheDocument();
+  });
+
+  it('shows a placeholder when a db sensor panel has no metadata', () => {
+    render(
+      <DashboardPanelGrid
+        panelOrder={['s:37']}
+        onPanelOrderChange={vi.fn()}
+        onRemovePanel={vi.fn()}
+        panelColumns={2}
+        chartProps={chartProps}
+      />,
+    );
+
+    expect(
+      screen.getByText('No data for the selected cells or date range.'),
+    ).toBeInTheDocument();
   });
 
   it('renders derived equation panels', () => {

--- a/frontend/src/pages/dashboard/components/UnifiedChart.jsx
+++ b/frontend/src/pages/dashboard/components/UnifiedChart.jsx
@@ -27,6 +27,7 @@ function getCellMeasurementData(cellData, measurement) {
 }
 function UnifiedChart({
   type,
+  sensorSpec = null,
   cells,
   startDate,
   endDate,
@@ -50,8 +51,24 @@ function UnifiedChart({
   const fetchGenerationRef = useRef(0);
   const sensorsById = cellSensorsById ?? EMPTY_CELL_SENSORS_BY_ID;
 
-  const config = CHART_CONFIGS[type];
-  const { sensor_name, measurements, units, axisIds, chartId, axisPolicy } = config || {};
+  const config = sensorSpec
+    ? {
+        sensor_name: sensorSpec.sensor_name,
+        measurements: sensorSpec.measurements,
+        units: sensorSpec.units ?? [''],
+        axisIds: sensorSpec.axisIds ?? ['y'],
+        chartId: sensorSpec.chartId ?? `db-sensor-${sensorSpec.sensor_name}`,
+        axisPolicy: sensorSpec.axisPolicy,
+      }
+    : CHART_CONFIGS[type];
+  const { sensor_name, measurements, units, axisIds, chartId, axisPolicy } = config || {
+    sensor_name: undefined,
+    measurements: [],
+    units: [],
+    axisIds: ['y'],
+    chartId: 'missing',
+    axisPolicy: undefined,
+  };
 
   const meas_colors = [
     '#26C6DA',
@@ -71,7 +88,13 @@ function UnifiedChart({
       if (historicalLoading || !historicalSensorByKey || Object.keys(historicalSensorByKey).length === 0) {
         return {};
       }
-      return buildUnifiedChartDataFromCache(cells, type, sensorsById, historicalSensorByKey);
+      return buildUnifiedChartDataFromCache(
+        cells,
+        type,
+        sensorsById,
+        historicalSensorByKey,
+        sensorSpec,
+      );
     }
 
     const cellEntries = await Promise.all(
@@ -396,6 +419,10 @@ function UnifiedChart({
     return null;
   }
 
+  if (!config) {
+    return <ChartPanelPlaceholder />;
+  }
+
   if (isLoading) {
     return <ChartPanelPlaceholder loading />;
   }
@@ -425,7 +452,15 @@ function UnifiedChart({
 }
 
 UnifiedChart.propTypes = {
-  type: PropTypes.oneOf(Object.keys(CHART_CONFIGS)).isRequired,
+  type: PropTypes.oneOf(Object.keys(CHART_CONFIGS)),
+  sensorSpec: PropTypes.shape({
+    sensor_name: PropTypes.string.isRequired,
+    measurements: PropTypes.arrayOf(PropTypes.string).isRequired,
+    units: PropTypes.arrayOf(PropTypes.string),
+    axisIds: PropTypes.arrayOf(PropTypes.string),
+    chartId: PropTypes.string,
+    axisPolicy: PropTypes.string,
+  }),
   cells: PropTypes.array,
   startDate: PropTypes.any,
   endDate: PropTypes.any,

--- a/frontend/src/services/catalog.js
+++ b/frontend/src/services/catalog.js
@@ -6,8 +6,12 @@ import axios from 'axios';
  * @property {string} label
  * @property {string} description
  * @property {string} category
- * @property {'builtin' | 'unified'} kind
+ * @property {'builtin' | 'unified' | 'sensor'} kind
  * @property {string} [unified_type]
+ * @property {number} [sensor_id]
+ * @property {string} [sensor_name]
+ * @property {string} [measurement]
+ * @property {string} [unit]
  */
 
 /**


### PR DESCRIPTION
## Summary

Fixes [#792](https://github.com/jlab-sensing/ENTS-backend/issues/792): cells can have rows in the `sensor` / `data` tables (visible in pgAdmin) but show no chartable panels in the dashboard because `GET /api/catalog/sensors` only scanned a hardcoded `_UNIFIED_SPECS` list.

This PR removes that discovery loop and builds catalog entries from **real `sensor` rows** that already have name / measurement / unit stored at ingest (via `ents` `parse_sensor_measurement`). The frontend accepts new `s:{sensorId}` panel IDs so users can add and plot those series.

## What changed

### Backend (`sensor_catalog.py`)
- Dropped `_UNIFIED_SPECS` / `_unified_available` discovery
- Query `sensor` for the cell where at least one `data` row exists
- Emit one entry per sensor:
  - `panel_id`: `s:{id}`
  - `kind`: `sensor`
  - `sensor_name`, `measurement`, `unit`, `label`, `description` from DB
- Keep legacy **power** / **TEROS** builtins from `power_data` / `teros_data` when present

### Frontend
- Treat `s:{id}` as a known panel type (layout URL, Add chart, default order)
- Map API `kind: "sensor"` entries in `catalogEntriesFromApi`
- Render `s:` panels in `DashboardPanelGrid` via `UnifiedChart` + `sensorSpec`
- Include DB sensor panels in central historical fetch (`collectDbSensorPanelRequests`)

### Tests
- Backend: builtins + unknown sensors with data; sensors without data omitted; empty cell
- Frontend: layout / catalog / cell-sensor layout coverage for `s:` panels

## Behavior notes

| Topic | Behavior |
|-------|----------|
| Discovery | Catalog lists sensors from DB (with data), not a hardcoded dict |
| Metadata | Name / measurement / unit come from DB (written at ingest) |
| Unknown sensors | Appear in **+ Add chart** (e.g. bootstrap upload types) |
| Layout URL | `s:37`-style tokens round-trip in `layout=` |
| Legacy `u:*` panels | Still supported for existing shared links |
| Live mode | Same as other unified charts |

## Test plan

- [ ] `GET /api/catalog/sensors?cell_id=1` returns builtins (if any) plus `s:{id}` entries for sensors with data
- [ ] Sensor in `sensor`/`data` that was **not** in old `_UNIFIED_SPECS` appears in **+ Add chart**
- [ ] Add that panel → chart plots → URL includes `s:` → hard refresh restores it
- [ ] Cell with only unknown `sensor` rows (no power/teros) still gets catalog entries
- [ ] Backend: `ENV_FILE=ci.env docker compose run --rm backend-test pytest tests/test_sensor_catalog.py -v`
- [ ] Frontend: `npm run lint` and `npm test -- --run`

## Follow-ups (out of scope)

- Fully retire leftover frontend `UNIFIED_CATALOG` / `CHART_CONFIGS` duplicates once layouts migrate to `s:` panels
- Decide whether power/TEROS should eventually come only from the generic `sensor` table
