### PR TITLE
Ignore TTN timesync requests

### DIFF
--- a/backend/api/resources/sensor_catalog.py
+++ b/backend/api/resources/sensor_catalog.py
@@ -14,7 +14,6 @@ from ..models.power_data import PowerData
 from ..models.sensor import Sensor
 from ..models.teros_data import TEROSData
 
-
 _BUILTIN_SPECS = [
     {
         "panel_id": "power-vi",

--- a/backend/api/resources/sensor_data.py
+++ b/backend/api/resources/sensor_data.py
@@ -107,24 +107,37 @@ class SensorData(Resource):
             Response indicating success or failure. See util.process_measurement
             for full description.
         """
+        
+        if ("uplink_message" in uplink_json and "f_port" in uplink_json["uplink_message"]):
 
-        if uplink_json["uplink_message"]["f_port"] == 1:
-            # get payload
-            payload_str = uplink_json["uplink_message"]["frm_payload"]
-            payload = base64.b64decode(payload_str)
+            if uplink_json["uplink_message"]["f_port"] == 1:
+                # get payload
+                payload_str = uplink_json["uplink_message"]["frm_payload"]
+                payload = base64.b64decode(payload_str)
 
-            resp = process_measurement(payload)
+                resp = process_measurement(payload)
 
-        elif uplink_json["uplink_message"]["f_port"] == 2:
-            payload_str = uplink_json["uplink_message"]["frm_payload"]
-            payload = base64.b64decode(payload_str)
+            elif uplink_json["uplink_message"]["f_port"] == 2:
+                payload_str = uplink_json["uplink_message"]["frm_payload"]
+                payload = base64.b64decode(payload_str)
 
-            resp = process_generic_measurement(payload)
+                resp = process_generic_measurement(payload)
+
+            elif uplink_json["uplink_message"]["f_port"] == 202:
+                resp = Response()
+                resp.status_code = 200
+                resp.set_data("Ignoring timesync request.")
+
+            else:
+                # don't process and return success
+                resp = Response()
+                resp.status_code = 404
+                resp.set_data("f_port not recognized.")
 
         else:
-            # don't process and return success
             resp = Response()
-            resp.status_code = 404
+            resp.status_code = 200
+            resp.set_data("Missing uplink_message or f_port.")
 
         return resp
 

--- a/backend/api/resources/sensor_data.py
+++ b/backend/api/resources/sensor_data.py
@@ -107,8 +107,11 @@ class SensorData(Resource):
             Response indicating success or failure. See util.process_measurement
             for full description.
         """
-        
-        if ("uplink_message" in uplink_json and "f_port" in uplink_json["uplink_message"]):
+
+        if (
+            "uplink_message" in uplink_json
+            and "f_port" in uplink_json["uplink_message"]
+        ):
 
             if uplink_json["uplink_message"]["f_port"] == 1:
                 # get payload

--- a/backend/api/resources/sensor_data.py
+++ b/backend/api/resources/sensor_data.py
@@ -112,7 +112,6 @@ class SensorData(Resource):
             "uplink_message" in uplink_json
             and "f_port" in uplink_json["uplink_message"]
         ):
-
             if uplink_json["uplink_message"]["f_port"] == 1:
                 # get payload
                 payload_str = uplink_json["uplink_message"]["frm_payload"]


### PR DESCRIPTION
Resolves #808.

In addition to the `f_port == 202` messages, sometimes blank uploads (no `f_port` or payload at all) are forwarded by TTN to dirtviz. These blank messages are sent as part of the timesync process and should be ignored (i.e. return `HTTP 200` to avoid the TTN webhook from declaring an error and rate-limiting subsequent packet forwards).